### PR TITLE
Fixed Transform on Android with HW-acceleration

### DIFF
--- a/Platforms/NGraphics.Android/AndroidPlatform.cs
+++ b/Platforms/NGraphics.Android/AndroidPlatform.cs
@@ -121,8 +121,7 @@ namespace NGraphics
 				(float)transform.B, (float)transform.D, (float)transform.F,
 				0, 0, 1,
 			});
-			t.PostConcat (graphics.Matrix);
-			graphics.Matrix = t;
+			graphics.Concat(t);
 		}
 		public void RestoreState ()
 		{


### PR DESCRIPTION
See: https://code.google.com/p/android/issues/detail?id=24517

Matrix-based Translation was broken on Android when Hardware-Acceleration was enabled.
Not sure if it applies to all Android versions, but was broken when I tested on 4.4.4.

The end result for the user was that user defined transformed were applied to the origin of the screen, rather than the currently active transform (usually positioned at the View's origin).

getMatrix() in Canvas.java is also deprecated, and should thus not be used:
https://github.com/android/platform_frameworks_base/blob/master/graphics/java/android/graphics/Canvas.java#L680

Using Canvas.concat(m) instead appears to fix this issue.