### PR TITLE
Implement MeasureText functionality

### DIFF
--- a/NGraphics/FilterCanvas.cs
+++ b/NGraphics/FilterCanvas.cs
@@ -30,6 +30,11 @@ namespace NGraphics
 			NextCanvas.RestoreState ();
 		}
 
+		public virtual Size MeasureText(string text, Font font)
+		{
+			return NextCanvas.MeasureText(text, font);
+		}
+
 		public virtual void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
 		{
 			NextCanvas.DrawText (text, frame, font, alignment, pen, brush);

--- a/NGraphics/GraphicCanvas.cs
+++ b/NGraphics/GraphicCanvas.cs
@@ -25,6 +25,10 @@ namespace NGraphics
 		{
 			throw new NotImplementedException ();
 		}
+		public Size MeasureText(string text, Font font)
+		{
+			throw new NotImplementedException();
+		}
 		public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
 		{
 			throw new NotImplementedException ();

--- a/NGraphics/ICanvas.cs
+++ b/NGraphics/ICanvas.cs
@@ -10,6 +10,7 @@ namespace NGraphics
 		void Transform (Transform transform);
 		void RestoreState ();
 
+		Size MeasureText(string text, Font font);
 		void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null);
 		void DrawPath (IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null);
 		void DrawRectangle (Rect frame, Pen pen = null, Brush brush = null);

--- a/NGraphics/NGraphics.csproj
+++ b/NGraphics/NGraphics.csproj
@@ -10,6 +10,8 @@
     <AssemblyName>NGraphics</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NGraphics/NullPlatform.cs
+++ b/NGraphics/NullPlatform.cs
@@ -45,6 +45,10 @@ namespace NGraphics
 			public void RestoreState ()
 			{
 			}
+			public Size MeasureText(string text, Font font)
+			{
+				return Size.Zero;
+			}
 			public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
 			{
 			}

--- a/Platforms/NGraphics.Android/AndroidPlatform.cs
+++ b/Platforms/NGraphics.Android/AndroidPlatform.cs
@@ -75,6 +75,22 @@ namespace NGraphics
 		{
 			bitmap.Compress (Bitmap.CompressFormat.Png, 100, stream);
 		}
+
+		public Size Size
+		{
+			get
+			{
+				return new Size(bitmap.Width, bitmap.Height);
+			}
+		}
+
+		public double Scale
+		{
+			get
+			{
+				return 1;
+			}
+		}
 	}
 
 	public class BitmapCanvas : CanvasCanvas, IImageCanvas
@@ -225,6 +241,15 @@ namespace NGraphics
 			}
 
 			throw new NotSupportedException ("Brush " + brush);
+		}
+
+		public Size MeasureText(string text, Font font)
+		{
+			var paint = GetFontPaint(font, TextAlignment.Left);
+			var w = paint.MeasureText (text);
+			var fm = paint.GetFontMetrics ();
+			var h = fm.Ascent + fm.Descent;
+			return new Size(w, h);
 		}
 
 		public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)

--- a/Platforms/NGraphics.Mac/ApplePlatform.cs
+++ b/Platforms/NGraphics.Mac/ApplePlatform.cs
@@ -213,6 +213,48 @@ namespace NGraphics
 			return new CGGradient (cs, comps, locs);
 		}
 
+		private static NSString NSFontAttributeName = new NSString("NSFontAttributeName");
+
+		public Size MeasureText(string text, Font font)
+		{
+			if (string.IsNullOrEmpty(text))
+				return Size.Zero;
+			if (font == null)
+				throw new ArgumentNullException("font");
+
+			string fontName = font.Name;
+			Array availableFonts =
+				#if __IOS__
+				UIKit.UIFont.FontNamesForFamilyName(fontName);
+				#else
+				AppKit.NSFontManager.SharedFontManager.AvailableMembersOfFontFamily (fontName).ToArray ();
+				#endif
+
+			#if __IOS__
+			UIKit.UIFont nsFont;
+			if (availableFonts != null && availableFonts.Length > 0)
+				nsFont = UIKit.UIFont.FromName(font.Name, (nfloat)font.Size);
+			else
+				nsFont = UIKit.UIFont.FromName("Georgia", (nfloat)font.Size);
+			#else
+			AppKit.NSFont nsFont;
+			if (availableFonts != null && availableFonts.Length > 0)
+				nsFont = AppKit.NSFont.FromFontName(font.Name, (nfloat)font.Size);
+			else
+				nsFont = AppKit.NSFont.FromFontName("Georgia", (nfloat)font.Size);
+			#endif
+
+			using (var s = new NSAttributedString(text, font: nsFont))
+			{
+				#if __IOS__
+				var result = s.GetBoundingRect(new CGSize(float.MaxValue, float.MaxValue), NSStringDrawingOptions.UsesDeviceMetrics, null);
+				#else
+				var result = s.BoundingRectWithSize(new CGSize(float.MaxValue, float.MaxValue), NSStringDrawingOptions.UsesDeviceMetrics);
+				#endif
+				return new Size(result.Width, result.Height);
+			}
+		}
+
 		public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
 		{
 			if (string.IsNullOrEmpty (text))

--- a/Platforms/NGraphics.Mac/ApplePlatform.cs
+++ b/Platforms/NGraphics.Mac/ApplePlatform.cs
@@ -245,6 +245,7 @@ namespace NGraphics
 			#endif
 
 			using (var s = new NSAttributedString(text, font: nsFont))
+			using (nsFont)
 			{
 				#if __IOS__
 				var result = s.GetBoundingRect(new CGSize(float.MaxValue, float.MaxValue), NSStringDrawingOptions.UsesDeviceMetrics, null);

--- a/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
+++ b/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
@@ -72,6 +72,22 @@ namespace NGraphics
 		{
 			image.Save (stream, ImageFormat.Png);
 		}
+
+		public Size Size
+		{
+			get
+			{
+				return new Size(image.Width, image.Height);
+			}
+		}
+
+		public double Scale
+		{
+			get
+			{
+				return 1;
+			}
+		}
 	}
 
 	public class BitmapCanvas : GraphicsCanvas, IImageCanvas
@@ -132,6 +148,15 @@ namespace NGraphics
 			if (stateStack.Count > 0) {
 				var s = stateStack.Pop ();
 				graphics.Restore (s);
+			}
+		}
+
+		public Size MeasureText(string text, Font font)
+		{
+			using (var netFont = new System.Drawing.Font(font.Name, (float)font.Size, FontStyle.Regular))
+			{
+				var result = graphics.MeasureString(text, netFont);
+				return new Size(result.Width, result.Height);
 			}
 		}
 

--- a/Platforms/NGraphics.iOS/NGraphics.iOS.csproj
+++ b/Platforms/NGraphics.iOS/NGraphics.iOS.csproj
@@ -9,6 +9,8 @@
     <RootNamespace>NGraphics.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>NGraphics.iOS</AssemblyName>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
It's important to be able to measure the size of text in order to lay it out properly.  My colleague pinged you on Twitter about this, but the suggestion to use horizontal alignment did not appear to work.  This pull request adds the method `MeasureText` to `ICanvas` and implements this across the various platforms.