### PR TITLE
Net format changes

### DIFF
--- a/NGraphics/Platforms.cs
+++ b/NGraphics/Platforms.cs
@@ -1,33 +1,33 @@
-using System;
-using System.Linq;
-using System.Reflection;
-
 namespace NGraphics
 {
-	public static class Platforms
-	{
-		static readonly IPlatform nulll = new NullPlatform ();
-		static IPlatform current = null;
+    public static class Platforms
+    {
+        static readonly IPlatform nulll = new NullPlatform();
+        private static IPlatform current = null;
 
-		public static IPlatform Null { get { return nulll; } }
+        public static IPlatform Null => nulll;
 
-		public static IPlatform Current {
-			get {
-				if (current == null) {
-					#if MAC
-					current = new ApplePlatform ();
-					#elif __IOS__
-					current = new ApplePlatform ();
-					#elif __ANDROID__
-					current = new AndroidPlatform ();
-					#elif NETFX_CORE
-					current = new WinRTPlatform ();
-					#else
-					current = new SystemDrawingPlatform ();
-					#endif
-				}
-				return current;
-			}
-		}
-	}
+        public static IPlatform Current
+        {
+            get
+            {
+                if (current == null)
+                {
+#if MAC
+                    current = new ApplePlatform ();
+#elif __IOS__
+                    current = new ApplePlatform ();
+#elif __ANDROID__
+                    current = new AndroidPlatform ();
+#elif NETFX_CORE
+                    current = new WinRTPlatform ();
+#else
+                    current = new SystemDrawingPlatform();
+#endif
+                }
+
+                return current;
+            }
+        }
+    }
 }

--- a/Platforms/NGraphics.Net.Test/Program.cs
+++ b/Platforms/NGraphics.Net.Test/Program.cs
@@ -1,53 +1,62 @@
-﻿using System;
-using System.IO;
-using NGraphics.Test;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace NGraphics.Net.Test
+﻿namespace NGraphics.Net.Test
 {
-	class MainClass
-	{
-		public static void Main (string[] args)
-		{
-			RunTests ().Wait ();
-		}
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NGraphics.Test;
 
-		static async Task RunTests ()
-		{
-			var sdir = System.IO.Path.GetDirectoryName (Environment.GetCommandLineArgs () [0]);
-			while (Directory.GetFiles (sdir, "NGraphics.sln").Length == 0)
-				sdir = System.IO.Path.GetDirectoryName (sdir);
-			PlatformTest.ResultsDirectory = System.IO.Path.Combine (sdir, "TestResults");
-			PlatformTest.Platform = Platforms.Current;
-			Environment.CurrentDirectory = PlatformTest.ResultsDirectory;
+    public class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            RunTests().Wait();
+        }
 
-			var tat = typeof(NUnit.Framework.TestAttribute);
-			var tfat = typeof(NUnit.Framework.TestFixtureAttribute);
+        private static async Task RunTests()
+        {
+            var sdir = Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
+            while (Directory.GetFiles(sdir, "NGraphics.sln").Length == 0)
+            {
+                sdir = Path.GetDirectoryName(sdir);
+            }
 
-			var types = typeof (DrawingTest).Assembly.GetTypes ();
-			var tfts = types.Where (t => t.GetCustomAttributes (tfat, false).Length > 0);
+            PlatformTest.ResultsDirectory = Path.Combine(sdir, "TestResults");
+            PlatformTest.Platform = Platforms.Current;
+            Environment.CurrentDirectory = PlatformTest.ResultsDirectory;
 
-			foreach (var t in tfts) {
-				var test = Activator.CreateInstance (t);
-				var ms = t.GetMethods ().Where (m => m.GetCustomAttributes (tat, true).Length > 0);
-				foreach (var m in ms) {
-					Console.WriteLine ("Running {0}...", m);
+            var tat = typeof(NUnit.Framework.TestAttribute);
+            var tfat = typeof(NUnit.Framework.TestFixtureAttribute);
 
-					try {
-						var r = m.Invoke (test, null);
-						var ta = r as Task;
-						if (ta != null)
-							await ta;
-					}
-					catch (Exception ex) {
-						Console.WriteLine (ex);
-						Console.ReadLine ();
-					}
-				}
-			}
+            var types = typeof(DrawingTest).Assembly.GetTypes();
+            var tfts = types.Where(t => t.GetCustomAttributes(tfat, false).Length > 0);
 
-			Console.WriteLine ("Done");
-		}
-	}
+            foreach (var t in tfts)
+            {
+                var test = Activator.CreateInstance(t);
+                var ms = t.GetMethods().Where(m => m.GetCustomAttributes(tat, true).Length > 0);
+                foreach (var m in ms)
+                {
+                    Console.WriteLine("Running {0}...", m);
+
+                    try
+                    {
+                        var r = m.Invoke(test, null);
+                        var ta = r as Task;
+                        if (ta != null)
+                        {
+                            await ta;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex);
+                        Console.ReadLine();
+                    }
+                }
+            }
+
+            Console.WriteLine("Done");
+        }
+    }
 }

--- a/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
+++ b/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
@@ -169,13 +169,13 @@ namespace NGraphics
 
         public void DrawText(string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
         {
-            if (brush == null)  throw new ArgumentNullException(nameof(brush)); 
-
+            if (brush == null)
+                throw new ArgumentNullException(nameof(brush));
             var sdfont = new System.Drawing.Font(font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
             var sz = graphics.MeasureString(text, sdfont);
             var point = frame.Position;
             var fr = new Rect(point, new Size(sz.Width, sz.Height));
-            graphics.DrawString(text, sdfont, Conversions.GetBrush(brush, fr), Conversions.GetPointF(point));// - new Point(0, sdfont.Height)));
+            graphics.DrawString(text, sdfont, Conversions.GetBrush(brush, fr), Conversions.GetPointF(point));
         }
         public void DrawPath(IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
         {
@@ -421,4 +421,3 @@ namespace NGraphics
         }
     }
 }
-

--- a/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
+++ b/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
@@ -12,41 +12,39 @@ namespace NGraphics
     {
         public string Name { get { return "Net"; } }
 
-        public IImageCanvas CreateImageCanvas(Size size, double scale = 1.0, bool transparency = true)
+        public IImageCanvas CreateImageCanvas (Size size, double scale = 1.0, bool transparency = true)
         {
-            var pixelWidth = (int)Math.Ceiling(size.Width * scale);
-            var pixelHeight = (int)Math.Ceiling(size.Height * scale);
+            var pixelWidth = (int)Math.Ceiling (size.Width * scale);
+            var pixelHeight = (int)Math.Ceiling (size.Height * scale);
             var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
-            var bitmap = new Bitmap(pixelWidth, pixelHeight, format);
-            return new BitmapCanvas(bitmap, scale);
+            var bitmap = new Bitmap (pixelWidth, pixelHeight, format);
+            return new BitmapCanvas (bitmap, scale);
         }
 
-        public IImage LoadImage(Stream stream)
+        public IImage LoadImage (Stream stream)
         {
-            var image = Image.FromStream(stream);
-            return new ImageImage(image);
+            var image = Image.FromStream (stream);
+            return new ImageImage (image);
         }
 
-        public IImage LoadImage(string path)
+        public IImage LoadImage (string path)
         {
             var image = Image.FromFile(path);
             return new ImageImage(image);
         }
 
-        public IImage CreateImage(Color[] colors, int width, double scale = 1.0)
+        public IImage CreateImage (Color[] colors, int width, double scale = 1.0)
         {
             var pixelWidth = width;
             var pixelHeight = colors.Length / width;
             var format = PixelFormat.Format32bppArgb;
             Bitmap bitmap;
-            unsafe
-            {
-                fixed (Color* c = colors)
-                {
-                    bitmap = new Bitmap(pixelWidth, pixelHeight, pixelWidth * 4, format, new IntPtr(c));
+            unsafe {
+                fixed (Color* c = colors) {
+                    bitmap = new Bitmap (pixelWidth, pixelHeight, pixelWidth * 4, format, new IntPtr(c));
                 }
             }
-            return new ImageImage(bitmap);
+            return new ImageImage (bitmap);
         }
     }
 
@@ -54,25 +52,23 @@ namespace NGraphics
     {
         readonly Image image;
 
-        public Image Image
-        {
-            get
-            {
+        public Image Image {
+            get {
                 return image;
             }
         }
 
-        public ImageImage(Image image)
+        public ImageImage (Image image)
         {
             this.image = image;
         }
 
-        public void SaveAsPng(string path)
+        public void SaveAsPng (string path)
         {
-            image.Save(path, ImageFormat.Png);
+            image.Save (path, ImageFormat.Png);
         }
 
-        public void SaveAsPng(Stream stream)
+        public void SaveAsPng (Stream stream)
         {
             image.Save(stream, ImageFormat.Png);
         }
@@ -81,7 +77,7 @@ namespace NGraphics
         {
             get
             {
-                return new Size(image.Width, image.Height);
+                return new Size (image.Width, image.Height);
             }
         }
 
@@ -102,13 +98,13 @@ namespace NGraphics
         public Size Size { get { return new Size(bitmap.Width / scale, bitmap.Height / scale); } }
         public double Scale { get { return scale; } }
 
-        public BitmapCanvas(Bitmap bitmap, double scale = 1.0)
-            : base(Graphics.FromImage(bitmap))
+        public BitmapCanvas (Bitmap bitmap, double scale = 1.0)
+            : base (Graphics.FromImage(bitmap))
         {
             this.bitmap = bitmap;
             this.scale = scale;
 
-            graphics.ScaleTransform((float)scale, (float)scale);
+            graphics.ScaleTransform ((float)scale, (float)scale);
         }
 
         public IImage GetImage()
@@ -122,7 +118,7 @@ namespace NGraphics
         protected readonly Graphics graphics;
         readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState>();
 
-        public GraphicsCanvas(Graphics graphics)
+        public GraphicsCanvas (Graphics graphics)
         {
             this.graphics = graphics;
 
@@ -135,24 +131,21 @@ namespace NGraphics
             var s = graphics.Save();
             stateStack.Push(s);
         }
-        public void Transform(Transform transform)
+        public void Transform (Transform transform)
         {
-            try
-            {
-                graphics.MultiplyTransform(new Matrix(
+            try {
+                graphics.MultiplyTransform(new Matrix (
                     (float)transform.A, (float)transform.B,
                     (float)transform.C, (float)transform.D,
                     (float)transform.E, (float)transform.F), MatrixOrder.Prepend);
             }
-            catch (Exception ex)
-            {
+            catch (Exception ex) {
                 Console.WriteLine(ex);
             }
         }
         public void RestoreState()
         {
-            if (stateStack.Count > 0)
-            {
+            if (stateStack.Count > 0) {
                 var s = stateStack.Pop();
                 graphics.Restore(s);
             }
@@ -160,77 +153,70 @@ namespace NGraphics
 
         public Size MeasureText(string text, Font font)
         {
-            using (var netFont = new System.Drawing.Font(font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
+            using (var netFont = new System.Drawing.Font (font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
             {
-                var result = graphics.MeasureString(text, netFont);
-                return new Size(result.Width, result.Height);
+                var result = graphics.MeasureString (text, netFont);
+                return new Size (result.Width, result.Height);
             }
         }
 
-        public void DrawText(string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
+        public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
         {
             if (brush == null)
                 throw new ArgumentNullException(nameof(brush));
-            var sdfont = new System.Drawing.Font(font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
-            var sz = graphics.MeasureString(text, sdfont);
+            var sdfont = new System.Drawing.Font (font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
+            var sz = graphics.MeasureString (text, sdfont);
             var point = frame.Position;
-            var fr = new Rect(point, new Size(sz.Width, sz.Height));
-            graphics.DrawString(text, sdfont, Conversions.GetBrush(brush, fr), Conversions.GetPointF(point));
+            var fr = new Rect (point, new Size (sz.Width, sz.Height));
+            graphics.DrawString (text, sdfont, Conversions.GetBrush (brush, fr), Conversions.GetPointF (point));
         }
-        public void DrawPath(IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
+        public void DrawPath (IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
         {
-            using (var path = new GraphicsPath())
-            {
+            using (var path = new GraphicsPath ()) {
 
-                var bb = new BoundingBoxBuilder();
+                var bb = new BoundingBoxBuilder ();
 
                 var position = Point.Zero;
 
-                foreach (var op in ops)
-                {
+                foreach (var op in ops) {
                     var mt = op as MoveTo;
-                    if (mt != null)
-                    {
+                    if (mt != null) {
                         var p = mt.Point;
                         position = p;
-                        bb.Add(p);
+                        bb.Add (p);
                         continue;
                     }
                     var lt = op as LineTo;
-                    if (lt != null)
-                    {
+                    if (lt != null) {
                         var p = lt.Point;
-                        path.AddLine(Conversions.GetPointF(position), Conversions.GetPointF(p));
+                        path.AddLine (Conversions.GetPointF(position), Conversions.GetPointF(p));
                         position = p;
-                        bb.Add(p);
+                        bb.Add (p);
                         continue;
                     }
                     var at = op as ArcTo;
-                    if (at != null)
-                    {
+                    if (at != null) {
                         var p = at.Point;
-                        path.AddLine(Conversions.GetPointF(position), Conversions.GetPointF(p));
+                        path.AddLine (Conversions.GetPointF(position), Conversions.GetPointF(p));
                         position = p;
-                        bb.Add(p);
+                        bb.Add (p);
                         continue;
                     }
                     var ct = op as CurveTo;
-                    if (ct != null)
-                    {
+                    if (ct != null) {
                         var p = ct.Point;
                         var c1 = ct.Control1;
                         var c2 = ct.Control2;
-                        path.AddBezier(Conversions.GetPointF(position), Conversions.GetPointF(c1),
+                        path.AddBezier (Conversions.GetPointF(position), Conversions.GetPointF(c1),
                             Conversions.GetPointF(c2), Conversions.GetPointF(p));
                         position = p;
-                        bb.Add(p);
-                        bb.Add(c1);
-                        bb.Add(c2);
+                        bb.Add (p);
+                        bb.Add (c1);
+                        bb.Add (c2);
                         continue;
                     }
                     var cp = op as ClosePath;
-                    if (cp != null)
-                    {
+                    if (cp != null) {
                         path.CloseFigure();
                         continue;
                     }
@@ -239,47 +225,39 @@ namespace NGraphics
                 }
 
                 var frame = bb.BoundingBox;
-                if (brush != null)
-                {
-                    graphics.FillPath(brush.GetBrush(frame), path);
+                if (brush != null) {
+                    graphics.FillPath (brush.GetBrush(frame), path);
                 }
-                if (pen != null)
-                {
+                if (pen != null) {
                     var r = Conversions.GetRectangleF(frame);
-                    graphics.DrawPath(pen.GetPen(), path);
+                    graphics.DrawPath (pen.GetPen(), path);
                 }
             }
         }
-        public void DrawRectangle(Rect frame, Pen pen = null, Brush brush = null)
+        public void DrawRectangle (Rect frame, Pen pen = null, Brush brush = null)
         {
-            if (brush != null)
-            {
-                graphics.FillRectangle(brush.GetBrush(frame), Conversions.GetRectangleF(frame));
+            if (brush != null) {
+                graphics.FillRectangle (brush.GetBrush(frame), Conversions.GetRectangleF (frame));
             }
-            if (pen != null)
-            {
+            if (pen != null) {
                 var r = Conversions.GetRectangleF(frame);
-                graphics.DrawRectangle(pen.GetPen(), r.X, r.Y, r.Width, r.Height);
+                graphics.DrawRectangle (pen.GetPen (), r.X, r.Y, r.Width, r.Height);
             }
         }
-        public void DrawEllipse(Rect frame, Pen pen = null, Brush brush = null)
+        public void DrawEllipse (Rect frame, Pen pen = null, Brush brush = null)
         {
-            if (brush != null)
-            {
-                graphics.FillEllipse(brush.GetBrush(frame), Conversions.GetRectangleF(frame));
+            if (brush != null) {
+                graphics.FillEllipse (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
             }
-            if (pen != null)
-            {
-                graphics.DrawEllipse(pen.GetPen(), Conversions.GetRectangleF(frame));
+            if (pen != null) {
+                graphics.DrawEllipse (pen.GetPen (), Conversions.GetRectangleF (frame));
             }
         }
-        public void DrawImage(IImage image, Rect frame, double alpha = 1.0)
+        public void DrawImage (IImage image, Rect frame, double alpha = 1.0)
         {
             var ii = image as ImageImage;
-            if (ii != null)
-            {
-                if (alpha < 0.999)
-                {
+            if (ii != null) {
+                if (alpha < 0.999) {
                     var i = new ImageAttributes();
                     var mat = new ColorMatrix(new float[][] {
                         new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
@@ -288,14 +266,12 @@ namespace NGraphics
                         new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
                         new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
                     });
-                    i.SetColorMatrix(mat);
+                    i.SetColorMatrix (mat);
                     var size = ii.Image.Size;
-                    graphics.DrawImage(ii.Image, Conversions.GetRectangle(frame),
+                    graphics.DrawImage (ii.Image, Conversions.GetRectangle(frame),
                         0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
-                }
-                else
-                {
-                    graphics.DrawImage(ii.Image, Conversions.GetRectangleF(frame));
+                } else {
+                    graphics.DrawImage (ii.Image, Conversions.GetRectangleF(frame));
                 }
             }
         }
@@ -303,17 +279,17 @@ namespace NGraphics
 
     public static class Conversions
     {
-        public static System.Drawing.Color GetColor(this Color color)
+        public static System.Drawing.Color GetColor (this Color color)
         {
-            return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+            return System.Drawing.Color.FromArgb (color.A, color.R, color.G, color.B);
         }
 
-        public static System.Drawing.Pen GetPen(this Pen pen)
+        public static System.Drawing.Pen GetPen (this Pen pen)
         {
-            return new System.Drawing.Pen(GetColor(pen.Color), (float)pen.Width);
+            return new System.Drawing.Pen (GetColor (pen.Color), (float)pen.Width);
         }
 
-        static ColorBlend BuildBlend(List<GradientStop> stops, bool reverse = false)
+        static ColorBlend BuildBlend (List<GradientStop> stops, bool reverse = false)
         {
             if (stops.Count < 2)
                 return null;
@@ -324,100 +300,89 @@ namespace NGraphics
             // Build the blend
             var n = stops.Count;
             var an = 0;
-            if (s1.Offset != 0)
-            {
+            if (s1.Offset != 0) {
                 an++;
             }
-            if (s2.Offset != 1)
-            {
+            if (s2.Offset != 1) {
                 an++;
             }
             var blend = new System.Drawing.Drawing2D.ColorBlend(n + an);
             var o = 0;
-            if (s1.Offset != 0)
-            {
-                blend.Colors[0] = GetColor(s1.Color);
+            if (s1.Offset != 0) {
+                blend.Colors[0] = GetColor (s1.Color);
                 blend.Positions[0] = 0;
                 o = 1;
             }
-            for (var i = 0; i < n; i++)
-            {
-                blend.Colors[i + o] = GetColor(stops[i].Color);
+            for (var i = 0; i < n; i++) {
+                blend.Colors[i + o] = GetColor (stops[i].Color);
                 blend.Positions[i + o] = (float)stops[i].Offset;
             }
-            if (s2.Offset != 1)
-            {
-                blend.Colors[n + an - 1] = GetColor(s1.Color);
+            if (s2.Offset != 1) {
+                blend.Colors[n + an - 1] = GetColor (s1.Color);
                 blend.Positions[n + an - 1] = 1;
             }
 
-            if (reverse)
-            {
-                for (var i = 0; i < blend.Positions.Length; i++)
-                {
+            if (reverse) {
+                for (var i = 0; i < blend.Positions.Length; i++) {
                     blend.Positions[i] = 1 - blend.Positions[i];
                 }
-                Array.Reverse(blend.Positions);
-                Array.Reverse(blend.Colors);
+                Array.Reverse (blend.Positions);
+                Array.Reverse (blend.Colors);
             }
 
             return blend;
         }
 
-        public static System.Drawing.Brush GetBrush(this Brush brush, Rect frame)
+        public static System.Drawing.Brush GetBrush (this Brush brush, Rect frame)
         {
             var cb = brush as SolidBrush;
-            if (cb != null)
-            {
-                return new System.Drawing.SolidBrush(cb.Color.GetColor());
+            if (cb != null) {
+                return new System.Drawing.SolidBrush (cb.Color.GetColor ());
             }
 
             var lgb = brush as LinearGradientBrush;
-            if (lgb != null)
-            {
+            if (lgb != null) {
                 var s = lgb.Absolute ? lgb.Start : frame.Position + lgb.Start * frame.Size;
                 var e = lgb.Absolute ? lgb.End : frame.Position + lgb.End * frame.Size;
-                var b = new System.Drawing.Drawing2D.LinearGradientBrush(GetPointF(s), GetPointF(e), System.Drawing.Color.Black, System.Drawing.Color.Black);
-                var bb = BuildBlend(lgb.Stops);
-                if (bb != null)
-                {
+                var b = new System.Drawing.Drawing2D.LinearGradientBrush (GetPointF (s), GetPointF (e), System.Drawing.Color.Black, System.Drawing.Color.Black);
+                var bb = BuildBlend (lgb.Stops);
+                if (bb != null) {
                     b.InterpolationColors = bb;
                 }
                 return b;
             }
 
             var rgb = brush as RadialGradientBrush;
-            if (rgb != null)
-            {
-                var r = rgb.GetAbsoluteRadius(frame);
-                var c = rgb.GetAbsoluteCenter(frame);
-                var path = new GraphicsPath();
-                path.AddEllipse(GetRectangleF(new Rect(c - r, 2 * r)));
-                var b = new PathGradientBrush(path);
-                var bb = BuildBlend(rgb.Stops, true);
-                if (bb != null)
-                {
+            if (rgb != null) {
+                var r = rgb.GetAbsoluteRadius (frame);
+                var c = rgb.GetAbsoluteCenter (frame);
+                var path = new GraphicsPath ();
+                path.AddEllipse(GetRectangleF (new Rect (c - r, 2 * r)));
+                var b = new PathGradientBrush (path);
+                var bb = BuildBlend (rgb.Stops, true);
+                if (bb != null) {
                     b.InterpolationColors = bb;
                 }
                 return b;
             }
 
-            throw new NotImplementedException("Brush " + brush);
+            throw new NotImplementedException ("Brush " + brush);
         }
 
-        public static PointF GetPointF(this Point point)
+        public static PointF GetPointF (this Point point)
         {
-            return new PointF((float)point.X, (float)point.Y);
+            return new PointF ((float)point.X, (float)point.Y);
         }
 
-        public static RectangleF GetRectangleF(this Rect frame)
+        public static RectangleF GetRectangleF (this Rect frame)
         {
-            return new RectangleF((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
+            return new RectangleF ((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
         }
 
-        public static System.Drawing.Rectangle GetRectangle(this Rect frame)
+        public static System.Drawing.Rectangle GetRectangle (this Rect frame)
         {
-            return new System.Drawing.Rectangle((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
+            return new System.Drawing.Rectangle ((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
         }
     }
 }
+

--- a/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
+++ b/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
@@ -8,288 +8,312 @@ using System.Threading.Tasks;
 
 namespace NGraphics
 {
-	public class SystemDrawingPlatform : IPlatform
-	{
-		public string Name { get { return "Net"; } }
+    public class SystemDrawingPlatform : IPlatform
+    {
+        public string Name { get { return "Net"; } }
 
-		public IImageCanvas CreateImageCanvas (Size size, double scale = 1.0, bool transparency = true)
-		{
-			var pixelWidth = (int)Math.Ceiling (size.Width * scale);
-			var pixelHeight = (int)Math.Ceiling (size.Height * scale);
-			var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
-			var bitmap = new Bitmap (pixelWidth, pixelHeight, format);
-			return new BitmapCanvas (bitmap, scale);
-		}
+        public IImageCanvas CreateImageCanvas(Size size, double scale = 1.0, bool transparency = true)
+        {
+            var pixelWidth = (int)Math.Ceiling(size.Width * scale);
+            var pixelHeight = (int)Math.Ceiling(size.Height * scale);
+            var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
+            var bitmap = new Bitmap(pixelWidth, pixelHeight, format);
+            return new BitmapCanvas(bitmap, scale);
+        }
 
-		public IImage LoadImage (Stream stream)
-		{
-			var image = Image.FromStream (stream);
-			return new ImageImage (image);
-		}
+        public IImage LoadImage(Stream stream)
+        {
+            var image = Image.FromStream(stream);
+            return new ImageImage(image);
+        }
 
-		public IImage LoadImage (string path)
-		{
-			var image = Image.FromFile (path);
-			return new ImageImage (image);
-		}
+        public IImage LoadImage(string path)
+        {
+            var image = Image.FromFile(path);
+            return new ImageImage(image);
+        }
 
-		public IImage CreateImage (Color[] colors, int width, double scale = 1.0)
-		{
-			var pixelWidth = width;
-			var pixelHeight = colors.Length / width;
-			var format = PixelFormat.Format32bppArgb;
-			Bitmap bitmap;
-			unsafe {
-				fixed (Color *c = colors) {
-					bitmap = new Bitmap (pixelWidth, pixelHeight, pixelWidth*4, format, new IntPtr (c));
-				}
-			}
-			return new ImageImage (bitmap);
-		}
-	}
+        public IImage CreateImage(Color[] colors, int width, double scale = 1.0)
+        {
+            var pixelWidth = width;
+            var pixelHeight = colors.Length / width;
+            var format = PixelFormat.Format32bppArgb;
+            Bitmap bitmap;
+            unsafe
+            {
+                fixed (Color* c = colors)
+                {
+                    bitmap = new Bitmap(pixelWidth, pixelHeight, pixelWidth * 4, format, new IntPtr(c));
+                }
+            }
+            return new ImageImage(bitmap);
+        }
+    }
 
-	public class ImageImage : IImage
-	{
-		readonly Image image;
+    public class ImageImage : IImage
+    {
+        readonly Image image;
 
-		public Image Image {
-			get {
-				return image;
-			}
-		}
+        public Image Image
+        {
+            get
+            {
+                return image;
+            }
+        }
 
-		public ImageImage (Image image)
-		{
-			this.image = image;
-		}
+        public ImageImage(Image image)
+        {
+            this.image = image;
+        }
 
-		public void SaveAsPng (string path)
-		{
-			image.Save (path, ImageFormat.Png);
-		}
+        public void SaveAsPng(string path)
+        {
+            image.Save(path, ImageFormat.Png);
+        }
 
-		public void SaveAsPng (Stream stream)
-		{
-			image.Save (stream, ImageFormat.Png);
-		}
+        public void SaveAsPng(Stream stream)
+        {
+            image.Save(stream, ImageFormat.Png);
+        }
 
-		public Size Size
-		{
-			get
-			{
-				return new Size(image.Width, image.Height);
-			}
-		}
+        public Size Size
+        {
+            get
+            {
+                return new Size(image.Width, image.Height);
+            }
+        }
 
-		public double Scale
-		{
-			get
-			{
-				return 1;
-			}
-		}
-	}
+        public double Scale
+        {
+            get
+            {
+                return 1;
+            }
+        }
+    }
 
-	public class BitmapCanvas : GraphicsCanvas, IImageCanvas
-	{
-		readonly Bitmap bitmap;
-		readonly double scale;
+    public class BitmapCanvas : GraphicsCanvas, IImageCanvas
+    {
+        readonly Bitmap bitmap;
+        readonly double scale;
 
-		public Size Size { get { return new Size (bitmap.Width / scale, bitmap.Height / scale); } }
-		public double Scale { get { return scale; } }
+        public Size Size { get { return new Size(bitmap.Width / scale, bitmap.Height / scale); } }
+        public double Scale { get { return scale; } }
 
-		public BitmapCanvas (Bitmap bitmap, double scale = 1.0)
-			: base (Graphics.FromImage (bitmap))
-		{
-			this.bitmap = bitmap;
-			this.scale = scale;
+        public BitmapCanvas(Bitmap bitmap, double scale = 1.0)
+            : base(Graphics.FromImage(bitmap))
+        {
+            this.bitmap = bitmap;
+            this.scale = scale;
 
-			graphics.ScaleTransform ((float)scale, (float)scale);
-		}
+            graphics.ScaleTransform((float)scale, (float)scale);
+        }
 
-		public IImage GetImage ()
-		{
-			return new ImageImage (bitmap);
-		}
-	}
+        public IImage GetImage()
+        {
+            return new ImageImage(bitmap);
+        }
+    }
 
-	public class GraphicsCanvas : ICanvas
-	{
-		protected readonly Graphics graphics;
-		readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState> ();
+    public class GraphicsCanvas : ICanvas
+    {
+        protected readonly Graphics graphics;
+        readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState>();
 
-		public GraphicsCanvas (Graphics graphics)
-		{
-			this.graphics = graphics;
+        public GraphicsCanvas(Graphics graphics)
+        {
+            this.graphics = graphics;
 
             graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
-			graphics.SmoothingMode = SmoothingMode.HighQuality;
-		}
+            graphics.SmoothingMode = SmoothingMode.HighQuality;
+        }
 
-		public void SaveState ()
-		{
-			var s = graphics.Save ();
-			stateStack.Push (s);
-		}
-		public void Transform (Transform transform)
-		{
-			try {
-				graphics.MultiplyTransform (new Matrix (
-					(float)transform.A, (float)transform.B,
-					(float)transform.C, (float)transform.D,
-					(float)transform.E, (float)transform.F), MatrixOrder.Prepend);
-			}
-			catch (Exception ex) {
-				Console.WriteLine (ex);
-			}
-		}
-		public void RestoreState ()
-		{
-			if (stateStack.Count > 0) {
-				var s = stateStack.Pop ();
-				graphics.Restore (s);
-			}
-		}
+        public void SaveState()
+        {
+            var s = graphics.Save();
+            stateStack.Push(s);
+        }
+        public void Transform(Transform transform)
+        {
+            try
+            {
+                graphics.MultiplyTransform(new Matrix(
+                    (float)transform.A, (float)transform.B,
+                    (float)transform.C, (float)transform.D,
+                    (float)transform.E, (float)transform.F), MatrixOrder.Prepend);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+        public void RestoreState()
+        {
+            if (stateStack.Count > 0)
+            {
+                var s = stateStack.Pop();
+                graphics.Restore(s);
+            }
+        }
 
-		public Size MeasureText(string text, Font font)
-		{
-			using (var netFont = new System.Drawing.Font(font.Name, (float)font.Size, FontStyle.Regular))
-			{
-				var result = graphics.MeasureString(text, netFont);
-				return new Size(result.Width, result.Height);
-			}
-		}
+        public Size MeasureText(string text, Font font)
+        {
+            using (var netFont = new System.Drawing.Font(font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
+            {
+                var result = graphics.MeasureString(text, netFont);
+                return new Size(result.Width, result.Height);
+            }
+        }
 
-		public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
-		{
-			if (brush == null)
-				return;
-			var sdfont = new System.Drawing.Font (font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Pixel);
-			var sz = graphics.MeasureString (text, sdfont);
-			var point = frame.Position;
-            var fr = new Rect (point, new Size (sz.Width, sz.Height));
-            graphics.DrawString (text, sdfont, Conversions.GetBrush (brush, fr), Conversions.GetPointF (point - new Point (0, sdfont.Height)));
-		}
-		public void DrawPath (IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
-		{
-			using (var path = new GraphicsPath ()) {
+        public void DrawText(string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
+        {
+            if (brush == null)  throw new ArgumentNullException(nameof(brush)); 
 
-                var bb = new BoundingBoxBuilder ();
+            var sdfont = new System.Drawing.Font(font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
+            var sz = graphics.MeasureString(text, sdfont);
+            var point = frame.Position;
+            var fr = new Rect(point, new Size(sz.Width, sz.Height));
+            graphics.DrawString(text, sdfont, Conversions.GetBrush(brush, fr), Conversions.GetPointF(point));// - new Point(0, sdfont.Height)));
+        }
+        public void DrawPath(IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
+        {
+            using (var path = new GraphicsPath())
+            {
 
-				var position = Point.Zero;
+                var bb = new BoundingBoxBuilder();
 
-				foreach (var op in ops) {
-					var mt = op as MoveTo;
-					if (mt != null) {
-						var p = mt.Point;
-						position = p;
-                        bb.Add (p);
-						continue;
-					}
-					var lt = op as LineTo;
-					if (lt != null) {
-						var p = lt.Point;
-						path.AddLine (Conversions.GetPointF (position), Conversions.GetPointF (p));
-						position = p;
-                        bb.Add (p);
-                        continue;
-					}
-                    var at = op as ArcTo;
-                    if (at != null) {
-                        var p = at.Point;
-                        path.AddLine (Conversions.GetPointF (position), Conversions.GetPointF (p));
+                var position = Point.Zero;
+
+                foreach (var op in ops)
+                {
+                    var mt = op as MoveTo;
+                    if (mt != null)
+                    {
+                        var p = mt.Point;
                         position = p;
-                        bb.Add (p);
+                        bb.Add(p);
+                        continue;
+                    }
+                    var lt = op as LineTo;
+                    if (lt != null)
+                    {
+                        var p = lt.Point;
+                        path.AddLine(Conversions.GetPointF(position), Conversions.GetPointF(p));
+                        position = p;
+                        bb.Add(p);
+                        continue;
+                    }
+                    var at = op as ArcTo;
+                    if (at != null)
+                    {
+                        var p = at.Point;
+                        path.AddLine(Conversions.GetPointF(position), Conversions.GetPointF(p));
+                        position = p;
+                        bb.Add(p);
                         continue;
                     }
                     var ct = op as CurveTo;
-                    if (ct != null) {
+                    if (ct != null)
+                    {
                         var p = ct.Point;
                         var c1 = ct.Control1;
                         var c2 = ct.Control2;
-                        path.AddBezier (Conversions.GetPointF (position), Conversions.GetPointF (c1),
-                            Conversions.GetPointF (c2), Conversions.GetPointF (p));
+                        path.AddBezier(Conversions.GetPointF(position), Conversions.GetPointF(c1),
+                            Conversions.GetPointF(c2), Conversions.GetPointF(p));
                         position = p;
-                        bb.Add (p);
-                        bb.Add (c1);
-                        bb.Add (c2);
+                        bb.Add(p);
+                        bb.Add(c1);
+                        bb.Add(c2);
                         continue;
                     }
                     var cp = op as ClosePath;
-					if (cp != null) {
-						path.CloseFigure ();
-						continue;
-					}
+                    if (cp != null)
+                    {
+                        path.CloseFigure();
+                        continue;
+                    }
 
-					throw new NotSupportedException ("Path Op " + op);
-				}
+                    throw new NotSupportedException("Path Op " + op);
+                }
 
-				var frame = bb.BoundingBox;
-				if (brush != null) {
-					graphics.FillPath (brush.GetBrush (frame), path);
-				}
-				if (pen != null) {
-					var r = Conversions.GetRectangleF (frame);
-					graphics.DrawPath (pen.GetPen (), path);
-				}
-			}
-		}
-		public void DrawRectangle (Rect frame, Pen pen = null, Brush brush = null)
-		{
-			if (brush != null) {
-				graphics.FillRectangle (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
-			}
-			if (pen != null) {
-				var r = Conversions.GetRectangleF (frame);
-				graphics.DrawRectangle (pen.GetPen (), r.X, r.Y, r.Width, r.Height);
-			}
-		}
-		public void DrawEllipse (Rect frame, Pen pen = null, Brush brush = null)
-		{
-			if (brush != null) {
-				graphics.FillEllipse (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
-			}
-			if (pen != null) {
-				graphics.DrawEllipse (pen.GetPen (), Conversions.GetRectangleF (frame));
-			}
-		}
-		public void DrawImage (IImage image, Rect frame, double alpha = 1.0)
-		{
-			var ii = image as ImageImage;
-			if (ii != null) {
-				if (alpha < 0.999) {
-					var i = new ImageAttributes ();
-					var mat = new ColorMatrix (new float[][] { 
-						new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
-						new[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f },
-						new[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f },
-						new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
-						new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
-					});
-					i.SetColorMatrix (mat);
-					var size = ii.Image.Size;
-					graphics.DrawImage (ii.Image, Conversions.GetRectangle (frame),
-						0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
-				} else {
-					graphics.DrawImage (ii.Image, Conversions.GetRectangleF (frame));
-				}
-			}
-		}
-	}
+                var frame = bb.BoundingBox;
+                if (brush != null)
+                {
+                    graphics.FillPath(brush.GetBrush(frame), path);
+                }
+                if (pen != null)
+                {
+                    var r = Conversions.GetRectangleF(frame);
+                    graphics.DrawPath(pen.GetPen(), path);
+                }
+            }
+        }
+        public void DrawRectangle(Rect frame, Pen pen = null, Brush brush = null)
+        {
+            if (brush != null)
+            {
+                graphics.FillRectangle(brush.GetBrush(frame), Conversions.GetRectangleF(frame));
+            }
+            if (pen != null)
+            {
+                var r = Conversions.GetRectangleF(frame);
+                graphics.DrawRectangle(pen.GetPen(), r.X, r.Y, r.Width, r.Height);
+            }
+        }
+        public void DrawEllipse(Rect frame, Pen pen = null, Brush brush = null)
+        {
+            if (brush != null)
+            {
+                graphics.FillEllipse(brush.GetBrush(frame), Conversions.GetRectangleF(frame));
+            }
+            if (pen != null)
+            {
+                graphics.DrawEllipse(pen.GetPen(), Conversions.GetRectangleF(frame));
+            }
+        }
+        public void DrawImage(IImage image, Rect frame, double alpha = 1.0)
+        {
+            var ii = image as ImageImage;
+            if (ii != null)
+            {
+                if (alpha < 0.999)
+                {
+                    var i = new ImageAttributes();
+                    var mat = new ColorMatrix(new float[][] {
+                        new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
+                        new[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f },
+                        new[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f },
+                        new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
+                        new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
+                    });
+                    i.SetColorMatrix(mat);
+                    var size = ii.Image.Size;
+                    graphics.DrawImage(ii.Image, Conversions.GetRectangle(frame),
+                        0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
+                }
+                else
+                {
+                    graphics.DrawImage(ii.Image, Conversions.GetRectangleF(frame));
+                }
+            }
+        }
+    }
 
-	public static class Conversions
-	{
-		public static System.Drawing.Color GetColor (this Color color)
-		{
-			return System.Drawing.Color.FromArgb (color.A, color.R, color.G, color.B);
-		}
+    public static class Conversions
+    {
+        public static System.Drawing.Color GetColor(this Color color)
+        {
+            return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+        }
 
-		public static System.Drawing.Pen GetPen (this Pen pen)
-		{
-			return new System.Drawing.Pen (GetColor (pen.Color), (float)pen.Width);
-		}
+        public static System.Drawing.Pen GetPen(this Pen pen)
+        {
+            return new System.Drawing.Pen(GetColor(pen.Color), (float)pen.Width);
+        }
 
-        static ColorBlend BuildBlend (List<GradientStop> stops, bool reverse = false)
+        static ColorBlend BuildBlend(List<GradientStop> stops, bool reverse = false)
         {
             if (stops.Count < 2)
                 return null;
@@ -300,89 +324,101 @@ namespace NGraphics
             // Build the blend
             var n = stops.Count;
             var an = 0;
-            if (s1.Offset != 0) {
+            if (s1.Offset != 0)
+            {
                 an++;
             }
-            if (s2.Offset != 1) {
+            if (s2.Offset != 1)
+            {
                 an++;
             }
-            var blend = new System.Drawing.Drawing2D.ColorBlend (n + an);
+            var blend = new System.Drawing.Drawing2D.ColorBlend(n + an);
             var o = 0;
-            if (s1.Offset != 0) {
-                blend.Colors[0] = GetColor (s1.Color);
+            if (s1.Offset != 0)
+            {
+                blend.Colors[0] = GetColor(s1.Color);
                 blend.Positions[0] = 0;
                 o = 1;
             }
-            for (var i = 0; i < n; i++) {
-                blend.Colors[i + o] = GetColor (stops[i].Color);
+            for (var i = 0; i < n; i++)
+            {
+                blend.Colors[i + o] = GetColor(stops[i].Color);
                 blend.Positions[i + o] = (float)stops[i].Offset;
             }
-            if (s2.Offset != 1) {
-                blend.Colors[n + an - 1] = GetColor (s1.Color);
+            if (s2.Offset != 1)
+            {
+                blend.Colors[n + an - 1] = GetColor(s1.Color);
                 blend.Positions[n + an - 1] = 1;
             }
 
-            if (reverse) {
-                for (var i = 0; i < blend.Positions.Length; i++) {
+            if (reverse)
+            {
+                for (var i = 0; i < blend.Positions.Length; i++)
+                {
                     blend.Positions[i] = 1 - blend.Positions[i];
                 }
-                Array.Reverse (blend.Positions);
-                Array.Reverse (blend.Colors);
+                Array.Reverse(blend.Positions);
+                Array.Reverse(blend.Colors);
             }
 
             return blend;
         }
 
-		public static System.Drawing.Brush GetBrush (this Brush brush, Rect frame)
-		{
-			var cb = brush as SolidBrush;
-			if (cb != null) {
-				return new System.Drawing.SolidBrush (cb.Color.GetColor ());
-			}
+        public static System.Drawing.Brush GetBrush(this Brush brush, Rect frame)
+        {
+            var cb = brush as SolidBrush;
+            if (cb != null)
+            {
+                return new System.Drawing.SolidBrush(cb.Color.GetColor());
+            }
 
             var lgb = brush as LinearGradientBrush;
-            if (lgb != null) {
+            if (lgb != null)
+            {
                 var s = lgb.Absolute ? lgb.Start : frame.Position + lgb.Start * frame.Size;
                 var e = lgb.Absolute ? lgb.End : frame.Position + lgb.End * frame.Size;
-                var b = new System.Drawing.Drawing2D.LinearGradientBrush (GetPointF (s), GetPointF (e), System.Drawing.Color.Black, System.Drawing.Color.Black);
-                var bb = BuildBlend (lgb.Stops);
-                if (bb != null) {
+                var b = new System.Drawing.Drawing2D.LinearGradientBrush(GetPointF(s), GetPointF(e), System.Drawing.Color.Black, System.Drawing.Color.Black);
+                var bb = BuildBlend(lgb.Stops);
+                if (bb != null)
+                {
                     b.InterpolationColors = bb;
                 }
                 return b;
             }
 
             var rgb = brush as RadialGradientBrush;
-            if (rgb != null) {
-                var r = rgb.GetAbsoluteRadius (frame);
-                var c = rgb.GetAbsoluteCenter (frame);
-                var path = new GraphicsPath ();
-                path.AddEllipse (GetRectangleF (new Rect (c - r, 2 * r)));
-                var b = new PathGradientBrush (path);
-                var bb = BuildBlend (rgb.Stops, true);
-                if (bb != null) {
+            if (rgb != null)
+            {
+                var r = rgb.GetAbsoluteRadius(frame);
+                var c = rgb.GetAbsoluteCenter(frame);
+                var path = new GraphicsPath();
+                path.AddEllipse(GetRectangleF(new Rect(c - r, 2 * r)));
+                var b = new PathGradientBrush(path);
+                var bb = BuildBlend(rgb.Stops, true);
+                if (bb != null)
+                {
                     b.InterpolationColors = bb;
                 }
                 return b;
             }
 
-			throw new NotImplementedException ("Brush " + brush);
-		}
-
-        public static PointF GetPointF (this Point point)
-        {
-            return new PointF ((float)point.X, (float)point.Y);
+            throw new NotImplementedException("Brush " + brush);
         }
 
-		public static RectangleF GetRectangleF (this Rect frame)
-		{
-			return new RectangleF ((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
-		}
+        public static PointF GetPointF(this Point point)
+        {
+            return new PointF((float)point.X, (float)point.Y);
+        }
 
-		public static System.Drawing.Rectangle GetRectangle (this Rect frame)
-		{
-			return new System.Drawing.Rectangle ((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
-		}
-	}
+        public static RectangleF GetRectangleF(this Rect frame)
+        {
+            return new RectangleF((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
+        }
+
+        public static System.Drawing.Rectangle GetRectangle(this Rect frame)
+        {
+            return new System.Drawing.Rectangle((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
+        }
+    }
 }
 

--- a/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
+++ b/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
@@ -1,298 +1,322 @@
-﻿using System;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Collections.Generic;
-using System.Drawing.Drawing2D;
-using System.IO;
-using System.Threading.Tasks;
-
-namespace NGraphics
+﻿namespace NGraphics
 {
-	public class SystemDrawingPlatform : IPlatform
-	{
-		public string Name { get { return "Net"; } }
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Drawing.Drawing2D;
+    using System.Drawing.Imaging;
+    using System.IO;
 
-		public IImageCanvas CreateImageCanvas (Size size, double scale = 1.0, bool transparency = true)
-		{
-			var pixelWidth = (int)Math.Ceiling (size.Width * scale);
-			var pixelHeight = (int)Math.Ceiling (size.Height * scale);
-			var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
-			var bitmap = new Bitmap (pixelWidth, pixelHeight, format);
-			return new BitmapCanvas (bitmap, scale);
-		}
+    public class SystemDrawingPlatform : IPlatform
+    {
+        public string Name => "Net";
 
-		public IImage LoadImage (Stream stream)
-		{
-			var image = Image.FromStream (stream);
-			return new ImageImage (image);
-		}
+        public IImageCanvas CreateImageCanvas(Size size, double scale = 1.0, bool transparency = true)
+        {
+            var pixelWidth = (int)Math.Ceiling(size.Width * scale);
+            var pixelHeight = (int)Math.Ceiling(size.Height * scale);
+            var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
+            var bitmap = new Bitmap(pixelWidth, pixelHeight, format);
+            return new BitmapCanvas(bitmap, scale);
+        }
 
-		public IImage LoadImage (string path)
-		{
-			var image = Image.FromFile (path);
-			return new ImageImage (image);
-		}
+        public IImage LoadImage(Stream stream)
+        {
+            var image = Image.FromStream(stream);
+            return new ImageImage(image);
+        }
 
-		public IImage CreateImage (Color[] colors, int width, double scale = 1.0)
-		{
-			var pixelWidth = width;
-			var pixelHeight = colors.Length / width;
-			var format = PixelFormat.Format32bppArgb;
-			Bitmap bitmap;
-			unsafe {
-				fixed (Color *c = colors) {
-					bitmap = new Bitmap (pixelWidth, pixelHeight, pixelWidth*4, format, new IntPtr (c));
-				}
-			}
-			return new ImageImage (bitmap);
-		}
-	}
+        public IImage LoadImage(string path)
+        {
+            var image = Image.FromFile(path);
+            return new ImageImage(image);
+        }
 
-	public class ImageImage : IImage
-	{
-		readonly Image image;
+        public IImage CreateImage(Color[] colors, int width, double scale = 1.0)
+        {
+            var pixelWidth = width;
+            var pixelHeight = colors.Length / width;
+            var format = PixelFormat.Format32bppArgb;
+            Bitmap bitmap;
+            unsafe
+            {
+                fixed (Color* c = colors)
+                {
+                    bitmap = new Bitmap(pixelWidth, pixelHeight, pixelWidth * 4, format, new IntPtr(c));
+                }
+            }
 
-		public Image Image {
-			get {
-				return image;
-			}
-		}
+            return new ImageImage(bitmap);
+        }
+    }
 
-		public ImageImage (Image image)
-		{
-			this.image = image;
-		}
+    public class ImageImage : IImage
+    {
+        readonly Image image;
 
-		public void SaveAsPng (string path)
-		{
-			image.Save (path, ImageFormat.Png);
-		}
+        public Image Image => image;
 
-		public void SaveAsPng (Stream stream)
-		{
-			image.Save (stream, ImageFormat.Png);
-		}
+        public ImageImage(Image image)
+        {
+            this.image = image;
+        }
 
-		public Size Size
-		{
-			get
-			{
-				return new Size(image.Width, image.Height);
-			}
-		}
+        public void SaveAsPng(string path)
+        {
+            image.Save(path, ImageFormat.Png);
+        }
 
-		public double Scale
-		{
-			get
-			{
-				return 1;
-			}
-		}
-	}
+        public void SaveAsPng(Stream stream)
+        {
+            image.Save(stream, ImageFormat.Png);
+        }
 
-	public class BitmapCanvas : GraphicsCanvas, IImageCanvas
-	{
-		readonly Bitmap bitmap;
-		readonly double scale;
+        public Size Size => new Size(image.Width, image.Height);
 
-		public Size Size { get { return new Size (bitmap.Width / scale, bitmap.Height / scale); } }
-		public double Scale { get { return scale; } }
+        public double Scale => 1;
+    }
 
-		public BitmapCanvas (Bitmap bitmap, double scale = 1.0)
-			: base (Graphics.FromImage (bitmap))
-		{
-			this.bitmap = bitmap;
-			this.scale = scale;
+    public class BitmapCanvas : GraphicsCanvas, IImageCanvas
+    {
+        private readonly Bitmap bitmap;
+        private readonly double scale;
 
-			graphics.ScaleTransform ((float)scale, (float)scale);
-		}
+        public Size Size => new Size(bitmap.Width / scale, bitmap.Height / scale);
 
-		public IImage GetImage ()
-		{
-			return new ImageImage (bitmap);
-		}
-	}
+        public double Scale => scale;
 
-	public class GraphicsCanvas : ICanvas
-	{
-		protected readonly Graphics graphics;
-		readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState> ();
+        public BitmapCanvas(Bitmap bitmap, double scale = 1.0)
+            : base(Graphics.FromImage(bitmap))
+        {
+            this.bitmap = bitmap;
+            this.scale = scale;
 
-		public GraphicsCanvas (Graphics graphics)
-		{
-			this.graphics = graphics;
+            graphics.ScaleTransform((float)scale, (float)scale);
+        }
+
+        public IImage GetImage()
+        {
+            return new ImageImage(bitmap);
+        }
+    }
+
+    public class GraphicsCanvas : ICanvas
+    {
+        protected readonly Graphics graphics;
+        private readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState>();
+
+        public GraphicsCanvas(Graphics graphics)
+        {
+            this.graphics = graphics;
 
             graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
-			graphics.SmoothingMode = SmoothingMode.HighQuality;
-		}
+            graphics.SmoothingMode = SmoothingMode.HighQuality;
+        }
 
-		public void SaveState ()
-		{
-			var s = graphics.Save ();
-			stateStack.Push (s);
-		}
-		public void Transform (Transform transform)
-		{
-			try {
-				graphics.MultiplyTransform (new Matrix (
-					(float)transform.A, (float)transform.B,
-					(float)transform.C, (float)transform.D,
-					(float)transform.E, (float)transform.F), MatrixOrder.Prepend);
-			}
-			catch (Exception ex) {
-				Console.WriteLine (ex);
-			}
-		}
-		public void RestoreState ()
-		{
-			if (stateStack.Count > 0) {
-				var s = stateStack.Pop ();
-				graphics.Restore (s);
-			}
-		}
+        public void SaveState()
+        {
+            var s = graphics.Save();
+            stateStack.Push(s);
+        }
 
-		public Size MeasureText(string text, Font font)
-		{
-			using (var netFont = new System.Drawing.Font (font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
-			{
-				var result = graphics.MeasureString(text, netFont);
-				return new Size(result.Width, result.Height);
-			}
-		}
+        public void Transform(Transform transform)
+        {
+            try
+            {
+                graphics.MultiplyTransform(
+                    new Matrix(
+                    (float)transform.A,
+                    (float)transform.B,
+                    (float)transform.C,
+                    (float)transform.D,
+                    (float)transform.E,
+                    (float)transform.F),
+                    MatrixOrder.Prepend);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
 
-		public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
-		{
-			if (brush == null)
-				throw new ArgumentNullException(nameof(brush));
-			var sdfont = new System.Drawing.Font (font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
-			var sz = graphics.MeasureString (text, sdfont);
-			var point = frame.Position;
-            var fr = new Rect (point, new Size (sz.Width, sz.Height));
-			graphics.DrawString (text, sdfont, Conversions.GetBrush (brush, fr), Conversions.GetPointF (point));
-		}
-		public void DrawPath (IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
-		{
-			using (var path = new GraphicsPath ()) {
+        public void RestoreState()
+        {
+            if (stateStack.Count > 0)
+            {
+                var s = stateStack.Pop();
+                graphics.Restore(s);
+            }
+        }
 
-                var bb = new BoundingBoxBuilder ();
+        public Size MeasureText(string text, Font font)
+        {
+            using (var netFont = new System.Drawing.Font(font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
+            {
+                var result = graphics.MeasureString(text, netFont);
+                return new Size(result.Width, result.Height);
+            }
+        }
 
-				var position = Point.Zero;
+        public void DrawText(string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
+        {
+            if (brush == null) throw new ArgumentNullException(nameof(brush));
 
-				foreach (var op in ops) {
-					var mt = op as MoveTo;
-					if (mt != null) {
-						var p = mt.Point;
-						position = p;
-                        bb.Add (p);
-						continue;
-					}
-					var lt = op as LineTo;
-					if (lt != null) {
-						var p = lt.Point;
-						path.AddLine (Conversions.GetPointF (position), Conversions.GetPointF (p));
-						position = p;
-                        bb.Add (p);
-                        continue;
-					}
-                    var at = op as ArcTo;
-                    if (at != null) {
-                        var p = at.Point;
-                        path.AddLine (Conversions.GetPointF (position), Conversions.GetPointF (p));
+            var sdfont = new System.Drawing.Font(font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
+            var sz = graphics.MeasureString(text, sdfont);
+            var point = frame.Position;
+            var fr = new Rect(point, new Size(sz.Width, sz.Height));
+            graphics.DrawString(text, sdfont, brush.GetBrush(fr), point.GetPointF());
+        }
+
+        public void DrawPath(IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
+        {
+            using (var path = new GraphicsPath())
+            {
+                var bb = new BoundingBoxBuilder();
+
+                var position = Point.Zero;
+
+                foreach (var op in ops)
+                {
+                    var mt = op as MoveTo;
+                    if (mt != null)
+                    {
+                        var p = mt.Point;
                         position = p;
-                        bb.Add (p);
+                        bb.Add(p);
                         continue;
                     }
+
+                    var lt = op as LineTo;
+                    if (lt != null)
+                    {
+                        var p = lt.Point;
+                        path.AddLine(position.GetPointF(), p.GetPointF());
+                        position = p;
+                        bb.Add(p);
+                        continue;
+                    }
+
+                    var at = op as ArcTo;
+                    if (at != null)
+                    {
+                        var p = at.Point;
+                        path.AddLine(position.GetPointF(), p.GetPointF());
+                        position = p;
+                        bb.Add(p);
+                        continue;
+                    }
+
                     var ct = op as CurveTo;
-                    if (ct != null) {
+                    if (ct != null)
+                    {
                         var p = ct.Point;
                         var c1 = ct.Control1;
                         var c2 = ct.Control2;
-                        path.AddBezier (Conversions.GetPointF (position), Conversions.GetPointF (c1),
-                            Conversions.GetPointF (c2), Conversions.GetPointF (p));
+                        path.AddBezier(position.GetPointF(), c1.GetPointF(), c2.GetPointF(), p.GetPointF());
                         position = p;
-                        bb.Add (p);
-                        bb.Add (c1);
-                        bb.Add (c2);
+                        bb.Add(p);
+                        bb.Add(c1);
+                        bb.Add(c2);
                         continue;
                     }
+
                     var cp = op as ClosePath;
-					if (cp != null) {
-						path.CloseFigure ();
-						continue;
-					}
+                    if (cp != null)
+                    {
+                        path.CloseFigure();
+                        continue;
+                    }
 
-					throw new NotSupportedException ("Path Op " + op);
-				}
+                    throw new NotSupportedException("Path Op " + op);
+                }
 
-				var frame = bb.BoundingBox;
-				if (brush != null) {
-					graphics.FillPath (brush.GetBrush (frame), path);
-				}
-				if (pen != null) {
-					var r = Conversions.GetRectangleF (frame);
-					graphics.DrawPath (pen.GetPen (), path);
-				}
-			}
-		}
-		public void DrawRectangle (Rect frame, Pen pen = null, Brush brush = null)
-		{
-			if (brush != null) {
-				graphics.FillRectangle (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
-			}
-			if (pen != null) {
-				var r = Conversions.GetRectangleF (frame);
-				graphics.DrawRectangle (pen.GetPen (), r.X, r.Y, r.Width, r.Height);
-			}
-		}
-		public void DrawEllipse (Rect frame, Pen pen = null, Brush brush = null)
-		{
-			if (brush != null) {
-				graphics.FillEllipse (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
-			}
-			if (pen != null) {
-				graphics.DrawEllipse (pen.GetPen (), Conversions.GetRectangleF (frame));
-			}
-		}
-		public void DrawImage (IImage image, Rect frame, double alpha = 1.0)
-		{
-			var ii = image as ImageImage;
-			if (ii != null) {
-				if (alpha < 0.999) {
-					var i = new ImageAttributes ();
-					var mat = new ColorMatrix (new float[][] { 
-						new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
-						new[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f },
-						new[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f },
-						new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
-						new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
-					});
-					i.SetColorMatrix (mat);
-					var size = ii.Image.Size;
-					graphics.DrawImage (ii.Image, Conversions.GetRectangle (frame),
-						0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
-				} else {
-					graphics.DrawImage (ii.Image, Conversions.GetRectangleF (frame));
-				}
-			}
-		}
-	}
+                var frame = bb.BoundingBox;
+                if (brush != null)
+                {
+                    graphics.FillPath(brush.GetBrush(frame), path);
+                }
 
-	public static class Conversions
-	{
-		public static System.Drawing.Color GetColor (this Color color)
-		{
-			return System.Drawing.Color.FromArgb (color.A, color.R, color.G, color.B);
-		}
+                if (pen != null)
+                {
+                    graphics.DrawPath(pen.GetPen(), path);
+                }
+            }
+        }
 
-		public static System.Drawing.Pen GetPen (this Pen pen)
-		{
-			return new System.Drawing.Pen (GetColor (pen.Color), (float)pen.Width);
-		}
+        public void DrawRectangle(Rect frame, Pen pen = null, Brush brush = null)
+        {
+            if (brush != null)
+            {
+                graphics.FillRectangle(brush.GetBrush(frame), frame.GetRectangleF());
+            }
 
-        static ColorBlend BuildBlend (List<GradientStop> stops, bool reverse = false)
+            if (pen != null)
+            {
+                var r = frame.GetRectangleF();
+                graphics.DrawRectangle(pen.GetPen(), r.X, r.Y, r.Width, r.Height);
+            }
+        }
+
+        public void DrawEllipse(Rect frame, Pen pen = null, Brush brush = null)
+        {
+            if (brush != null)
+            {
+                graphics.FillEllipse(brush.GetBrush(frame), frame.GetRectangleF());
+            }
+
+            if (pen != null)
+            {
+                graphics.DrawEllipse(pen.GetPen(), frame.GetRectangleF());
+            }
+        }
+
+        public void DrawImage(IImage image, Rect frame, double alpha = 1.0)
+        {
+            var ii = image as ImageImage;
+            if (ii != null)
+            {
+                if (alpha < 0.999)
+                {
+                    var i = new ImageAttributes();
+                    var mat = new ColorMatrix(new[]
+                    {
+                        new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
+                        new[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f },
+                        new[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f },
+                        new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
+                        new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
+                    });
+                    i.SetColorMatrix(mat);
+                    var size = ii.Image.Size;
+                    graphics.DrawImage(ii.Image, frame.GetRectangle(), 0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
+                }
+                else
+                {
+                    graphics.DrawImage(ii.Image, frame.GetRectangleF());
+                }
+            }
+        }
+    }
+
+    public static class Conversions
+    {
+        public static System.Drawing.Color GetColor(this Color color)
+        {
+            return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+        }
+
+        public static System.Drawing.Pen GetPen(this Pen pen)
+        {
+            return new System.Drawing.Pen(GetColor(pen.Color), (float)pen.Width);
+        }
+
+        public static ColorBlend BuildBlend(List<GradientStop> stops, bool reverse = false)
         {
             if (stops.Count < 2)
+            {
                 return null;
+            }
 
             var s1 = stops[0];
             var s2 = stops[stops.Count - 1];
@@ -300,89 +324,107 @@ namespace NGraphics
             // Build the blend
             var n = stops.Count;
             var an = 0;
-            if (s1.Offset != 0) {
+            if (s1.Offset != 0)
+            {
                 an++;
             }
-            if (s2.Offset != 1) {
+
+            if (s2.Offset != 1)
+            {
                 an++;
             }
-            var blend = new System.Drawing.Drawing2D.ColorBlend (n + an);
+
+            var blend = new ColorBlend(n + an);
             var o = 0;
-            if (s1.Offset != 0) {
-                blend.Colors[0] = GetColor (s1.Color);
+            if (s1.Offset != 0)
+            {
+                blend.Colors[0] = GetColor(s1.Color);
                 blend.Positions[0] = 0;
                 o = 1;
             }
-            for (var i = 0; i < n; i++) {
-                blend.Colors[i + o] = GetColor (stops[i].Color);
+
+            for (var i = 0; i < n; i++)
+            {
+                blend.Colors[i + o] = GetColor(stops[i].Color);
                 blend.Positions[i + o] = (float)stops[i].Offset;
             }
-            if (s2.Offset != 1) {
-                blend.Colors[n + an - 1] = GetColor (s1.Color);
+
+            if (s2.Offset != 1)
+            {
+                blend.Colors[n + an - 1] = GetColor(s1.Color);
                 blend.Positions[n + an - 1] = 1;
             }
 
-            if (reverse) {
-                for (var i = 0; i < blend.Positions.Length; i++) {
+            if (reverse)
+            {
+                for (var i = 0; i < blend.Positions.Length; i++)
+                {
                     blend.Positions[i] = 1 - blend.Positions[i];
                 }
-                Array.Reverse (blend.Positions);
-                Array.Reverse (blend.Colors);
+
+                Array.Reverse(blend.Positions);
+                Array.Reverse(blend.Colors);
             }
 
             return blend;
         }
 
-		public static System.Drawing.Brush GetBrush (this Brush brush, Rect frame)
-		{
-			var cb = brush as SolidBrush;
-			if (cb != null) {
-				return new System.Drawing.SolidBrush (cb.Color.GetColor ());
-			}
+        public static System.Drawing.Brush GetBrush(this Brush brush, Rect frame)
+        {
+            var cb = brush as SolidBrush;
+            if (cb != null)
+            {
+                return new System.Drawing.SolidBrush(cb.Color.GetColor());
+            }
 
             var lgb = brush as LinearGradientBrush;
-            if (lgb != null) {
-                var s = lgb.Absolute ? lgb.Start : frame.Position + lgb.Start * frame.Size;
-                var e = lgb.Absolute ? lgb.End : frame.Position + lgb.End * frame.Size;
-                var b = new System.Drawing.Drawing2D.LinearGradientBrush (GetPointF (s), GetPointF (e), System.Drawing.Color.Black, System.Drawing.Color.Black);
-                var bb = BuildBlend (lgb.Stops);
-                if (bb != null) {
+            if (lgb != null)
+            {
+                var s = lgb.Absolute ? lgb.Start : frame.Position + (lgb.Start * frame.Size);
+                var e = lgb.Absolute ? lgb.End : frame.Position + (lgb.End * frame.Size);
+                var b = new System.Drawing.Drawing2D.LinearGradientBrush(GetPointF(s), GetPointF(e), System.Drawing.Color.Black, System.Drawing.Color.Black);
+                var bb = BuildBlend(lgb.Stops);
+                if (bb != null)
+                {
                     b.InterpolationColors = bb;
                 }
+
                 return b;
             }
 
             var rgb = brush as RadialGradientBrush;
-            if (rgb != null) {
-                var r = rgb.GetAbsoluteRadius (frame);
-                var c = rgb.GetAbsoluteCenter (frame);
-                var path = new GraphicsPath ();
-                path.AddEllipse (GetRectangleF (new Rect (c - r, 2 * r)));
-                var b = new PathGradientBrush (path);
-                var bb = BuildBlend (rgb.Stops, true);
-                if (bb != null) {
+            if (rgb != null)
+            {
+                var r = rgb.GetAbsoluteRadius(frame);
+                var c = rgb.GetAbsoluteCenter(frame);
+                var path = new GraphicsPath();
+                path.AddEllipse(GetRectangleF(new Rect(c - r, 2 * r)));
+                var b = new PathGradientBrush(path);
+                var bb = BuildBlend(rgb.Stops, true);
+                if (bb != null)
+                {
                     b.InterpolationColors = bb;
                 }
+
                 return b;
             }
 
-			throw new NotImplementedException ("Brush " + brush);
-		}
-
-        public static PointF GetPointF (this Point point)
-        {
-            return new PointF ((float)point.X, (float)point.Y);
+            throw new NotImplementedException("Brush " + brush);
         }
 
-		public static RectangleF GetRectangleF (this Rect frame)
-		{
-			return new RectangleF ((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
-		}
+        public static PointF GetPointF(this Point point)
+        {
+            return new PointF((float)point.X, (float)point.Y);
+        }
 
-		public static System.Drawing.Rectangle GetRectangle (this Rect frame)
-		{
-			return new System.Drawing.Rectangle ((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
-		}
-	}
+        public static RectangleF GetRectangleF(this Rect frame)
+        {
+            return new RectangleF((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
+        }
+
+        public static System.Drawing.Rectangle GetRectangle(this Rect frame)
+        {
+            return new System.Drawing.Rectangle((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
+        }
+    }
 }
-

--- a/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
+++ b/Platforms/NGraphics.Net/SystemDrawingPlatform.cs
@@ -8,196 +8,196 @@ using System.Threading.Tasks;
 
 namespace NGraphics
 {
-    public class SystemDrawingPlatform : IPlatform
-    {
-        public string Name { get { return "Net"; } }
+	public class SystemDrawingPlatform : IPlatform
+	{
+		public string Name { get { return "Net"; } }
 
-        public IImageCanvas CreateImageCanvas (Size size, double scale = 1.0, bool transparency = true)
-        {
-            var pixelWidth = (int)Math.Ceiling (size.Width * scale);
-            var pixelHeight = (int)Math.Ceiling (size.Height * scale);
-            var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
-            var bitmap = new Bitmap (pixelWidth, pixelHeight, format);
-            return new BitmapCanvas (bitmap, scale);
-        }
+		public IImageCanvas CreateImageCanvas (Size size, double scale = 1.0, bool transparency = true)
+		{
+			var pixelWidth = (int)Math.Ceiling (size.Width * scale);
+			var pixelHeight = (int)Math.Ceiling (size.Height * scale);
+			var format = transparency ? PixelFormat.Format32bppPArgb : PixelFormat.Format24bppRgb;
+			var bitmap = new Bitmap (pixelWidth, pixelHeight, format);
+			return new BitmapCanvas (bitmap, scale);
+		}
 
-        public IImage LoadImage (Stream stream)
-        {
-            var image = Image.FromStream (stream);
-            return new ImageImage (image);
-        }
+		public IImage LoadImage (Stream stream)
+		{
+			var image = Image.FromStream (stream);
+			return new ImageImage (image);
+		}
 
-        public IImage LoadImage (string path)
-        {
-            var image = Image.FromFile(path);
-            return new ImageImage(image);
-        }
+		public IImage LoadImage (string path)
+		{
+			var image = Image.FromFile (path);
+			return new ImageImage (image);
+		}
 
-        public IImage CreateImage (Color[] colors, int width, double scale = 1.0)
-        {
-            var pixelWidth = width;
-            var pixelHeight = colors.Length / width;
-            var format = PixelFormat.Format32bppArgb;
-            Bitmap bitmap;
-            unsafe {
-                fixed (Color* c = colors) {
-                    bitmap = new Bitmap (pixelWidth, pixelHeight, pixelWidth * 4, format, new IntPtr(c));
-                }
-            }
-            return new ImageImage (bitmap);
-        }
-    }
+		public IImage CreateImage (Color[] colors, int width, double scale = 1.0)
+		{
+			var pixelWidth = width;
+			var pixelHeight = colors.Length / width;
+			var format = PixelFormat.Format32bppArgb;
+			Bitmap bitmap;
+			unsafe {
+				fixed (Color *c = colors) {
+					bitmap = new Bitmap (pixelWidth, pixelHeight, pixelWidth*4, format, new IntPtr (c));
+				}
+			}
+			return new ImageImage (bitmap);
+		}
+	}
 
-    public class ImageImage : IImage
-    {
-        readonly Image image;
+	public class ImageImage : IImage
+	{
+		readonly Image image;
 
-        public Image Image {
-            get {
-                return image;
-            }
-        }
+		public Image Image {
+			get {
+				return image;
+			}
+		}
 
-        public ImageImage (Image image)
-        {
-            this.image = image;
-        }
+		public ImageImage (Image image)
+		{
+			this.image = image;
+		}
 
-        public void SaveAsPng (string path)
-        {
-            image.Save (path, ImageFormat.Png);
-        }
+		public void SaveAsPng (string path)
+		{
+			image.Save (path, ImageFormat.Png);
+		}
 
-        public void SaveAsPng (Stream stream)
-        {
-            image.Save(stream, ImageFormat.Png);
-        }
+		public void SaveAsPng (Stream stream)
+		{
+			image.Save (stream, ImageFormat.Png);
+		}
 
-        public Size Size
-        {
-            get
-            {
-                return new Size (image.Width, image.Height);
-            }
-        }
+		public Size Size
+		{
+			get
+			{
+				return new Size(image.Width, image.Height);
+			}
+		}
 
-        public double Scale
-        {
-            get
-            {
-                return 1;
-            }
-        }
-    }
+		public double Scale
+		{
+			get
+			{
+				return 1;
+			}
+		}
+	}
 
-    public class BitmapCanvas : GraphicsCanvas, IImageCanvas
-    {
-        readonly Bitmap bitmap;
-        readonly double scale;
+	public class BitmapCanvas : GraphicsCanvas, IImageCanvas
+	{
+		readonly Bitmap bitmap;
+		readonly double scale;
 
-        public Size Size { get { return new Size(bitmap.Width / scale, bitmap.Height / scale); } }
-        public double Scale { get { return scale; } }
+		public Size Size { get { return new Size (bitmap.Width / scale, bitmap.Height / scale); } }
+		public double Scale { get { return scale; } }
 
-        public BitmapCanvas (Bitmap bitmap, double scale = 1.0)
-            : base (Graphics.FromImage(bitmap))
-        {
-            this.bitmap = bitmap;
-            this.scale = scale;
+		public BitmapCanvas (Bitmap bitmap, double scale = 1.0)
+			: base (Graphics.FromImage (bitmap))
+		{
+			this.bitmap = bitmap;
+			this.scale = scale;
 
-            graphics.ScaleTransform ((float)scale, (float)scale);
-        }
+			graphics.ScaleTransform ((float)scale, (float)scale);
+		}
 
-        public IImage GetImage()
-        {
-            return new ImageImage(bitmap);
-        }
-    }
+		public IImage GetImage ()
+		{
+			return new ImageImage (bitmap);
+		}
+	}
 
-    public class GraphicsCanvas : ICanvas
-    {
-        protected readonly Graphics graphics;
-        readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState>();
+	public class GraphicsCanvas : ICanvas
+	{
+		protected readonly Graphics graphics;
+		readonly Stack<GraphicsState> stateStack = new Stack<GraphicsState> ();
 
-        public GraphicsCanvas (Graphics graphics)
-        {
-            this.graphics = graphics;
+		public GraphicsCanvas (Graphics graphics)
+		{
+			this.graphics = graphics;
 
             graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
-            graphics.SmoothingMode = SmoothingMode.HighQuality;
-        }
+			graphics.SmoothingMode = SmoothingMode.HighQuality;
+		}
 
-        public void SaveState()
-        {
-            var s = graphics.Save();
-            stateStack.Push(s);
-        }
-        public void Transform (Transform transform)
-        {
-            try {
-                graphics.MultiplyTransform(new Matrix (
-                    (float)transform.A, (float)transform.B,
-                    (float)transform.C, (float)transform.D,
-                    (float)transform.E, (float)transform.F), MatrixOrder.Prepend);
-            }
-            catch (Exception ex) {
-                Console.WriteLine(ex);
-            }
-        }
-        public void RestoreState()
-        {
-            if (stateStack.Count > 0) {
-                var s = stateStack.Pop();
-                graphics.Restore(s);
-            }
-        }
+		public void SaveState ()
+		{
+			var s = graphics.Save ();
+			stateStack.Push (s);
+		}
+		public void Transform (Transform transform)
+		{
+			try {
+				graphics.MultiplyTransform (new Matrix (
+					(float)transform.A, (float)transform.B,
+					(float)transform.C, (float)transform.D,
+					(float)transform.E, (float)transform.F), MatrixOrder.Prepend);
+			}
+			catch (Exception ex) {
+				Console.WriteLine (ex);
+			}
+		}
+		public void RestoreState ()
+		{
+			if (stateStack.Count > 0) {
+				var s = stateStack.Pop ();
+				graphics.Restore (s);
+			}
+		}
 
-        public Size MeasureText(string text, Font font)
-        {
-            using (var netFont = new System.Drawing.Font (font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
-            {
-                var result = graphics.MeasureString (text, netFont);
-                return new Size (result.Width, result.Height);
-            }
-        }
+		public Size MeasureText(string text, Font font)
+		{
+			using (var netFont = new System.Drawing.Font (font.Name, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point))
+			{
+				var result = graphics.MeasureString(text, netFont);
+				return new Size(result.Width, result.Height);
+			}
+		}
 
-        public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
-        {
-            if (brush == null)
-                throw new ArgumentNullException(nameof(brush));
-            var sdfont = new System.Drawing.Font (font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
-            var sz = graphics.MeasureString (text, sdfont);
-            var point = frame.Position;
+		public void DrawText (string text, Rect frame, Font font, TextAlignment alignment = TextAlignment.Left, Pen pen = null, Brush brush = null)
+		{
+			if (brush == null)
+				throw new ArgumentNullException(nameof(brush));
+			var sdfont = new System.Drawing.Font (font.Family, (float)font.Size, FontStyle.Regular, GraphicsUnit.Point);
+			var sz = graphics.MeasureString (text, sdfont);
+			var point = frame.Position;
             var fr = new Rect (point, new Size (sz.Width, sz.Height));
-            graphics.DrawString (text, sdfont, Conversions.GetBrush (brush, fr), Conversions.GetPointF (point));
-        }
-        public void DrawPath (IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
-        {
-            using (var path = new GraphicsPath ()) {
+			graphics.DrawString (text, sdfont, Conversions.GetBrush (brush, fr), Conversions.GetPointF (point));
+		}
+		public void DrawPath (IEnumerable<PathOp> ops, Pen pen = null, Brush brush = null)
+		{
+			using (var path = new GraphicsPath ()) {
 
                 var bb = new BoundingBoxBuilder ();
 
-                var position = Point.Zero;
+				var position = Point.Zero;
 
-                foreach (var op in ops) {
-                    var mt = op as MoveTo;
-                    if (mt != null) {
-                        var p = mt.Point;
-                        position = p;
+				foreach (var op in ops) {
+					var mt = op as MoveTo;
+					if (mt != null) {
+						var p = mt.Point;
+						position = p;
+                        bb.Add (p);
+						continue;
+					}
+					var lt = op as LineTo;
+					if (lt != null) {
+						var p = lt.Point;
+						path.AddLine (Conversions.GetPointF (position), Conversions.GetPointF (p));
+						position = p;
                         bb.Add (p);
                         continue;
-                    }
-                    var lt = op as LineTo;
-                    if (lt != null) {
-                        var p = lt.Point;
-                        path.AddLine (Conversions.GetPointF(position), Conversions.GetPointF(p));
-                        position = p;
-                        bb.Add (p);
-                        continue;
-                    }
+					}
                     var at = op as ArcTo;
                     if (at != null) {
                         var p = at.Point;
-                        path.AddLine (Conversions.GetPointF(position), Conversions.GetPointF(p));
+                        path.AddLine (Conversions.GetPointF (position), Conversions.GetPointF (p));
                         position = p;
                         bb.Add (p);
                         continue;
@@ -207,8 +207,8 @@ namespace NGraphics
                         var p = ct.Point;
                         var c1 = ct.Control1;
                         var c2 = ct.Control2;
-                        path.AddBezier (Conversions.GetPointF(position), Conversions.GetPointF(c1),
-                            Conversions.GetPointF(c2), Conversions.GetPointF(p));
+                        path.AddBezier (Conversions.GetPointF (position), Conversions.GetPointF (c1),
+                            Conversions.GetPointF (c2), Conversions.GetPointF (p));
                         position = p;
                         bb.Add (p);
                         bb.Add (c1);
@@ -216,78 +216,78 @@ namespace NGraphics
                         continue;
                     }
                     var cp = op as ClosePath;
-                    if (cp != null) {
-                        path.CloseFigure();
-                        continue;
-                    }
+					if (cp != null) {
+						path.CloseFigure ();
+						continue;
+					}
 
-                    throw new NotSupportedException("Path Op " + op);
-                }
+					throw new NotSupportedException ("Path Op " + op);
+				}
 
-                var frame = bb.BoundingBox;
-                if (brush != null) {
-                    graphics.FillPath (brush.GetBrush(frame), path);
-                }
-                if (pen != null) {
-                    var r = Conversions.GetRectangleF(frame);
-                    graphics.DrawPath (pen.GetPen(), path);
-                }
-            }
-        }
-        public void DrawRectangle (Rect frame, Pen pen = null, Brush brush = null)
-        {
-            if (brush != null) {
-                graphics.FillRectangle (brush.GetBrush(frame), Conversions.GetRectangleF (frame));
-            }
-            if (pen != null) {
-                var r = Conversions.GetRectangleF(frame);
-                graphics.DrawRectangle (pen.GetPen (), r.X, r.Y, r.Width, r.Height);
-            }
-        }
-        public void DrawEllipse (Rect frame, Pen pen = null, Brush brush = null)
-        {
-            if (brush != null) {
-                graphics.FillEllipse (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
-            }
-            if (pen != null) {
-                graphics.DrawEllipse (pen.GetPen (), Conversions.GetRectangleF (frame));
-            }
-        }
-        public void DrawImage (IImage image, Rect frame, double alpha = 1.0)
-        {
-            var ii = image as ImageImage;
-            if (ii != null) {
-                if (alpha < 0.999) {
-                    var i = new ImageAttributes();
-                    var mat = new ColorMatrix(new float[][] {
-                        new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
-                        new[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f },
-                        new[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f },
-                        new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
-                        new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
-                    });
-                    i.SetColorMatrix (mat);
-                    var size = ii.Image.Size;
-                    graphics.DrawImage (ii.Image, Conversions.GetRectangle(frame),
-                        0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
-                } else {
-                    graphics.DrawImage (ii.Image, Conversions.GetRectangleF(frame));
-                }
-            }
-        }
-    }
+				var frame = bb.BoundingBox;
+				if (brush != null) {
+					graphics.FillPath (brush.GetBrush (frame), path);
+				}
+				if (pen != null) {
+					var r = Conversions.GetRectangleF (frame);
+					graphics.DrawPath (pen.GetPen (), path);
+				}
+			}
+		}
+		public void DrawRectangle (Rect frame, Pen pen = null, Brush brush = null)
+		{
+			if (brush != null) {
+				graphics.FillRectangle (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
+			}
+			if (pen != null) {
+				var r = Conversions.GetRectangleF (frame);
+				graphics.DrawRectangle (pen.GetPen (), r.X, r.Y, r.Width, r.Height);
+			}
+		}
+		public void DrawEllipse (Rect frame, Pen pen = null, Brush brush = null)
+		{
+			if (brush != null) {
+				graphics.FillEllipse (brush.GetBrush (frame), Conversions.GetRectangleF (frame));
+			}
+			if (pen != null) {
+				graphics.DrawEllipse (pen.GetPen (), Conversions.GetRectangleF (frame));
+			}
+		}
+		public void DrawImage (IImage image, Rect frame, double alpha = 1.0)
+		{
+			var ii = image as ImageImage;
+			if (ii != null) {
+				if (alpha < 0.999) {
+					var i = new ImageAttributes ();
+					var mat = new ColorMatrix (new float[][] { 
+						new[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f },
+						new[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f },
+						new[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f },
+						new[] { 0.0f, 0.0f, 0.0f, (float)alpha, 0.0f },
+						new[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }
+					});
+					i.SetColorMatrix (mat);
+					var size = ii.Image.Size;
+					graphics.DrawImage (ii.Image, Conversions.GetRectangle (frame),
+						0, 0, size.Width, size.Height, GraphicsUnit.Pixel, i);
+				} else {
+					graphics.DrawImage (ii.Image, Conversions.GetRectangleF (frame));
+				}
+			}
+		}
+	}
 
-    public static class Conversions
-    {
-        public static System.Drawing.Color GetColor (this Color color)
-        {
-            return System.Drawing.Color.FromArgb (color.A, color.R, color.G, color.B);
-        }
+	public static class Conversions
+	{
+		public static System.Drawing.Color GetColor (this Color color)
+		{
+			return System.Drawing.Color.FromArgb (color.A, color.R, color.G, color.B);
+		}
 
-        public static System.Drawing.Pen GetPen (this Pen pen)
-        {
-            return new System.Drawing.Pen (GetColor (pen.Color), (float)pen.Width);
-        }
+		public static System.Drawing.Pen GetPen (this Pen pen)
+		{
+			return new System.Drawing.Pen (GetColor (pen.Color), (float)pen.Width);
+		}
 
         static ColorBlend BuildBlend (List<GradientStop> stops, bool reverse = false)
         {
@@ -306,7 +306,7 @@ namespace NGraphics
             if (s2.Offset != 1) {
                 an++;
             }
-            var blend = new System.Drawing.Drawing2D.ColorBlend(n + an);
+            var blend = new System.Drawing.Drawing2D.ColorBlend (n + an);
             var o = 0;
             if (s1.Offset != 0) {
                 blend.Colors[0] = GetColor (s1.Color);
@@ -333,12 +333,12 @@ namespace NGraphics
             return blend;
         }
 
-        public static System.Drawing.Brush GetBrush (this Brush brush, Rect frame)
-        {
-            var cb = brush as SolidBrush;
-            if (cb != null) {
-                return new System.Drawing.SolidBrush (cb.Color.GetColor ());
-            }
+		public static System.Drawing.Brush GetBrush (this Brush brush, Rect frame)
+		{
+			var cb = brush as SolidBrush;
+			if (cb != null) {
+				return new System.Drawing.SolidBrush (cb.Color.GetColor ());
+			}
 
             var lgb = brush as LinearGradientBrush;
             if (lgb != null) {
@@ -357,7 +357,7 @@ namespace NGraphics
                 var r = rgb.GetAbsoluteRadius (frame);
                 var c = rgb.GetAbsoluteCenter (frame);
                 var path = new GraphicsPath ();
-                path.AddEllipse(GetRectangleF (new Rect (c - r, 2 * r)));
+                path.AddEllipse (GetRectangleF (new Rect (c - r, 2 * r)));
                 var b = new PathGradientBrush (path);
                 var bb = BuildBlend (rgb.Stops, true);
                 if (bb != null) {
@@ -366,23 +366,23 @@ namespace NGraphics
                 return b;
             }
 
-            throw new NotImplementedException ("Brush " + brush);
-        }
+			throw new NotImplementedException ("Brush " + brush);
+		}
 
         public static PointF GetPointF (this Point point)
         {
             return new PointF ((float)point.X, (float)point.Y);
         }
 
-        public static RectangleF GetRectangleF (this Rect frame)
-        {
-            return new RectangleF ((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
-        }
+		public static RectangleF GetRectangleF (this Rect frame)
+		{
+			return new RectangleF ((float)frame.X, (float)frame.Y, (float)frame.Width, (float)frame.Height);
+		}
 
-        public static System.Drawing.Rectangle GetRectangle (this Rect frame)
-        {
-            return new System.Drawing.Rectangle ((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
-        }
-    }
+		public static System.Drawing.Rectangle GetRectangle (this Rect frame)
+		{
+			return new System.Drawing.Rectangle ((int)frame.X, (int)frame.Y, (int)frame.Width, (int)frame.Height);
+		}
+	}
 }
 


### PR DESCRIPTION
Applied VS Edit.Format Document command. This replaces tabs with spaces for indentation and removes spaces before opening parenthesis (in method calls). Also added lines between elements (and after curly braces) as per StyleCop rules. Applied safe refactorings from VS code fixes and removed one unused code line. 