### PR TITLE
Creates a size from viewBox, if no size attribute supplied

### DIFF
--- a/NGraphics/SvgReader.cs
+++ b/NGraphics/SvgReader.cs
@@ -62,6 +62,10 @@ namespace NGraphics
 				size.Height *= viewBox.Height;
 			}
 
+			if (heightA == null && widthA == null && viewBoxA != null) {
+				size = new Size(viewBox.Width, viewBox.Height);
+			}
+
 			//
 			// Add the elements
 			//


### PR DESCRIPTION
This change will allow SVG files that have no size attributes for width and height specified to use the supplied viewBox/viewPort attribute to create a default graphic size 
