### PR TITLE
Add opacity to the group element

### DIFF
--- a/NGraphics.Test/Inputs/GroupOpacity.svg
+++ b/NGraphics.Test/Inputs/GroupOpacity.svg
@@ -1,0 +1,43 @@
+﻿<svg width="12cm" height="3.5cm" viewBox="0 0 1200 350"
+     xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <desc>Example opacity01 - opacity property</desc>
+
+  <rect x="1" y="1" width="1198" height="348"
+        fill="none" stroke="blue" />
+
+  <!-- Background blue rectangle -->
+  <rect x="100" y="100" width="1000" height="150" fill="#0000ff"  />
+
+  <!-- Red circles going from opaque to nearly transparent -->
+  <circle cx="200" cy="100" r="50" fill="red" opacity="1"  />
+  <circle cx="400" cy="100" r="50" fill="red" opacity=".8"  />
+  <circle cx="600" cy="100" r="50" fill="red" opacity=".6"  />
+  <circle cx="800" cy="100" r="50" fill="red" opacity=".4"  />
+  <circle cx="1000" cy="100" r="50" fill="red" opacity=".2"  />
+
+  <!-- Opaque group, opaque circles -->
+  <g opacity="1" >
+    <circle cx="182.5" cy="250" r="50" fill="red" opacity="1"  />
+    <circle cx="217.5" cy="250" r="50" fill="green" opacity="1"  />
+  </g>
+  <!-- Group opacity: .5, opacity circles -->
+  <g opacity=".5" >
+    <circle cx="382.5" cy="250" r="50" fill="red" opacity="1"  />
+    <circle cx="417.5" cy="250" r="50" fill="green" opacity="1"  />
+  </g>
+  <!-- Opaque group, semi-transparent green over red -->
+  <g opacity="1" >
+    <circle cx="582.5" cy="250" r="50" fill="red" opacity=".5"  />
+    <circle cx="617.5" cy="250" r="50" fill="green" opacity=".5"  />
+  </g>
+  <!-- Opaque group, semi-transparent red over green -->
+  <g opacity="1" >
+    <circle cx="817.5" cy="250" r="50" fill="green" opacity=".5"  />
+    <circle cx="782.5" cy="250" r="50" fill="red" opacity=".5"  />
+  </g>
+  <!-- Group opacity .5, semi-transparent green over red -->
+  <g opacity=".5" >
+    <circle cx="982.5" cy="250" r="50" fill="red" opacity=".5"  />
+    <circle cx="1017.5" cy="250" r="50" fill="green" opacity=".5"  />
+  </g>
+</svg>

--- a/NGraphics.Test/NGraphics.Test.csproj
+++ b/NGraphics.Test/NGraphics.Test.csproj
@@ -80,5 +80,6 @@
     <EmbeddedResource Include="Inputs\repeat.svg" />
     <EmbeddedResource Include="Inputs\sliderThumb.svg" />
     <EmbeddedResource Include="Inputs\TextVariations.svg" />
+    <EmbeddedResource Include="Inputs\GroupOpacity.svg" />
   </ItemGroup>
 </Project>

--- a/NGraphics.Test/SvgReaderTests.cs
+++ b/NGraphics.Test/SvgReaderTests.cs
@@ -137,6 +137,12 @@ namespace NGraphics.Test
 		{
 			await ReadAndDraw ("TextVariations.svg");
 		}
+
+		[Test]
+		public async Task GroupOpacity ()
+		{
+			await ReadAndDraw ("GroupOpacity.svg");
+		}
 	}
 }
 

--- a/NGraphics/SvgReader.cs
+++ b/NGraphics/SvgReader.cs
@@ -183,7 +183,13 @@ namespace NGraphics
 					var groupId = e.Attribute("id");
 					if (groupId != null && !string.IsNullOrEmpty(groupId.Value))
 						g.Id = groupId.Value;
+
+					var groupOpacity = e.Attribute ("opacity");
+					if (groupOpacity != null && !string.IsNullOrEmpty (groupOpacity.Value)) 
+						g.Opacity = ReadNumber (groupOpacity);
+
 					AddElements (g.Children, e.Elements (), pen, brush);
+
 					r = g;
 				}
 				break;
@@ -327,6 +333,9 @@ namespace NGraphics
 			}
 
 			var strokeOpacity = GetString (style, "stroke-opacity");
+			if (string.IsNullOrWhiteSpace (strokeOpacity))
+				strokeOpacity = GetString (style, "opacity");
+			
 			if (!string.IsNullOrWhiteSpace (strokeOpacity)) {
 				if (pen == null)
 					pen = new Pen ();
@@ -360,6 +369,9 @@ namespace NGraphics
 			// Brush attributes
 			//
 			var fillOpacity = GetString (style, "fill-opacity");
+			if (string.IsNullOrWhiteSpace (fillOpacity))
+				fillOpacity = GetString (style, "opacity");
+			
 			if (!string.IsNullOrWhiteSpace (fillOpacity)) {
 				if (brush == null)
 					brush = new SolidBrush ();


### PR DESCRIPTION
As per the Svg 1.1 reference, a group or container element can have an opacity setting:

[14.5 Object and group opacity: the ‘opacity’ property](https://www.w3.org/TR/SVG/masking.html#OpacityProperty)

**I'd like to implement support for group opacity by:**
- Adding support for opacity as a short for fill-opacity (will affect both pen and brush) on elements
- Adding support for multiplying the group's opacity with its children's pen/brush opacity.

**Solution:**
- To avoid changing too many classes we can let the Group object visit its children before and after drawing to change its children's alpha values (pens and brushes). 
- Visiting children should not be performed if no opacity is set on the group.
- Subsequent assignments to the group's opacity property should not result in alpha values growing in either direction.
