### PR TITLE
Added support for specifying the brush to use for the default stroke/fill

### DIFF
--- a/NGraphics.Test/SvgReaderTests.cs
+++ b/NGraphics.Test/SvgReaderTests.cs
@@ -15,10 +15,10 @@ namespace NGraphics.Test
 	[TestFixture]
 	public class SvgReaderTests : PlatformTest
 	{
-		Graphic Read (string path)
+		Graphic Read (string path, Brush defaultBrush = null)
 		{
 			using (var s = OpenResource (path)) {
-				var r = new SvgReader (new StreamReader (s));
+				var r = new SvgReader (new StreamReader (s), defaultBrush: defaultBrush);
 				Assert.IsTrue (r.Graphic.Children.Count >= 0);
 				Assert.IsTrue (r.Graphic.Size.Width > 1);
 				Assert.IsTrue (r.Graphic.Size.Height > 1);
@@ -26,9 +26,11 @@ namespace NGraphics.Test
 			}
 		}
 
-		async Task ReadAndDraw (string path)
+		async Task ReadAndDraw (string path, Brush defaultBrush = null)
 		{
-			var g = Read (path);
+            // If no brush is provided in the SVG, use a pleasing shade of green.
+            defaultBrush = defaultBrush ?? Brushes.Green;
+			var g = Read (path, defaultBrush);
 
 			//
 			// Draw Image

--- a/NGraphics/Graphic.cs
+++ b/NGraphics/Graphic.cs
@@ -74,9 +74,9 @@ namespace NGraphics
 			canvas.RestoreState ();
 		}
 
-		public static Graphic LoadSvg (System.IO.TextReader reader)
+		public static Graphic LoadSvg (System.IO.TextReader reader, Brush defaultBrush = null)
 		{
-			var svgr = new SvgReader (reader);
+            var svgr = new SvgReader (reader, defaultBrush: defaultBrush);
 			return svgr.Graphic;
 		}
 

--- a/NGraphics/SvgReader.cs
+++ b/NGraphics/SvgReader.cs
@@ -19,13 +19,14 @@ namespace NGraphics
 		readonly Dictionary<string, XElement> defs = new Dictionary<string, XElement> ();
 //		readonly XNamespace ns;
 
-		public SvgReader (System.IO.TextReader reader, double pixelsPerInch = 160.0)
+		public SvgReader (System.IO.TextReader reader, double pixelsPerInch = 160.0, Brush defaultBrush = null)
 		{
-			PixelsPerInch = pixelsPerInch;
-			Read (XDocument.Load (reader));
+            defaultBrush = defaultBrush ?? Brushes.Black;
+            PixelsPerInch = pixelsPerInch;
+			Read (XDocument.Load (reader), defaultBrush);
 		}
 
-		void Read (XDocument doc)
+		void Read (XDocument doc, Brush defaultBrush)
 		{
 			var svg = doc.Root;
 			var ns = svg.Name.Namespace;
@@ -67,7 +68,7 @@ namespace NGraphics
 			//
 			Graphic = new Graphic (size, viewBox);
 
-			AddElements (Graphic.Children, svg.Elements (), null, Brushes.Black);
+			AddElements (Graphic.Children, svg.Elements (), null, defaultBrush);
 		}
 
 		void AddElements (IList<Element> list, IEnumerable<XElement> es, Pen inheritPen, Brush inheritBrush)


### PR DESCRIPTION
Hello! We found ourselves wanting the ability to specify which color to use when loading an SVG and no explicit stroke/fill colors are set. The changes here will continue to use Black as the brush if nothing is specified, but it does allow the user to indicate a color if they prefer a different default.

I've modified the test cases to use Green as the default brush, and it now causes the mozilla.ellipse and mozilla.Text2 and mozilla.Text3 test cases (which do not specify a color) to render as green.
